### PR TITLE
Make all credentials fields allow for fallback and override

### DIFF
--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -32,7 +32,20 @@ def get_credentials():
     """
     config = hookenv.config()
 
-    creds_data = {}
+    required_fields = [
+        'auth_url',
+        'region',
+        'username',
+        'password',
+        'user_domain_name',
+        'project_domain_name',
+        'project_name',
+    ]
+    optional_fields = [
+        'endpoint_tls_ca',
+    ]
+    # pre-populate with empty values to avoid key and arg errors
+    creds_data = {field: '' for field in required_fields + optional_fields}
 
     # try to use Juju's trust feature
     try:
@@ -63,13 +76,7 @@ def get_credentials():
     # merge in individual config
     _merge_if_set(creds_data, _normalize_creds(config))
 
-    if all([creds_data['auth_url'],
-            creds_data['username'],
-            creds_data['password'],
-            creds_data['project_name'],
-            creds_data['user_domain_name'],
-            creds_data['project_domain_name'],
-            creds_data['region']]):
+    if all(v for k, v in creds_data.items() if k in required_fields):
         _save_creds(creds_data)
         return True
     else:

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -133,11 +133,13 @@ def _normalize_creds(creds_data):
     # interface expects it b64 encoded; that seems unnecessary,
     # but we should ensure that it follows the interface docs
     if ca_cert:
+        ca_cert = ca_cert.decode('utf8')  # b64 deals with bytes
         try:
             ca_cert = b64decode(ca_cert)
         except Exception:
             pass  # might not be encoded
         ca_cert = b64encode(ca_cert)  # ensure is encoded
+        ca_cert = ca_cert.encode('utf8')  # relations deal with strings
 
     return dict(
         auth_url=endpoint,

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -113,13 +113,17 @@ def _normalize_creds(creds_data):
         endpoint = attrs['auth-url']
         region = attrs['region']
 
-    if 'ca-certificates' in creds_data:
+    # seems like this might have changed at some point;
+    # newer controllers return the latter
+    trust_ca_keys = {'ca-certificates', 'cacertificates'}
+    if trust_ca_keys & creds_data.keys():
         # see K8s commit e3c8a0ceb66816433b095c4d734663e1b1e0e4ea
         # K8s in-tree cloud provider code is not flexible enough
         # to accept multiple certs that could be provided by Juju
         # so we can grab the first one only and hope it is the
         # right one
-        ca_certificates = creds_data.get('ca-certificates')
+        trust_ca_key = (trust_ca_keys & creds_data.keys())[0]
+        ca_certificates = creds_data[trust_ca_key]
         ca_cert = ca_certificates[0] if ca_certificates else None
     elif 'endpoint-tls-ca' in creds_data:
         ca_cert = creds_data['endpoint-tls-ca']

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -122,7 +122,7 @@ def _normalize_creds(creds_data):
         # to accept multiple certs that could be provided by Juju
         # so we can grab the first one only and hope it is the
         # right one
-        trust_ca_key = (trust_ca_keys & creds_data.keys())[0]
+        trust_ca_key = (trust_ca_keys & creds_data.keys()).pop()
         ca_certificates = creds_data[trust_ca_key]
         ca_cert = ca_certificates[0] if ca_certificates else None
     elif 'endpoint-tls-ca' in creds_data:

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -133,13 +133,13 @@ def _normalize_creds(creds_data):
     # interface expects it b64 encoded; that seems unnecessary,
     # but we should ensure that it follows the interface docs
     if ca_cert:
-        ca_cert = ca_cert.decode('utf8')  # b64 deals with bytes
+        ca_cert = ca_cert.encode('utf8')  # b64 deals with bytes
         try:
             ca_cert = b64decode(ca_cert)
         except Exception:
             pass  # might not be encoded
         ca_cert = b64encode(ca_cert)  # ensure is encoded
-        ca_cert = ca_cert.encode('utf8')  # relations deal with strings
+        ca_cert = ca_cert.decode('utf8')  # relations deal with strings
 
     return dict(
         auth_url=endpoint,

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -62,13 +62,13 @@ def get_credentials():
     # try individual config
     creds_data.update(_normalize_creds(config))
 
-    if all([config['auth-url'],
-            config['username'],
-            config['password'],
-            config['project-name'],
-            config['user-domain-name'],
-            config['project-domain-name'],
-            config['region']]):
+    if all([creds_data['auth_url'],
+            creds_data['username'],
+            creds_data['password'],
+            creds_data['project_name'],
+            creds_data['user_domain_name'],
+            creds_data['project_domain_name'],
+            creds_data['region']]):
         _save_creds(creds_data)
         return True
     else:

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -76,7 +76,7 @@ def get_credentials():
     # merge in individual config
     _merge_if_set(creds_data, _normalize_creds(config))
 
-    if all(v for k, v in creds_data.items() if k in required_fields):
+    if all(creds_data[k] for k in required_fields):
         _save_creds(creds_data)
         return True
     else:

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -54,7 +54,7 @@ def get_credentials():
                                 check=True,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
-        _creds_data = yaml.load(result.stdout.decode('utf8'))
+        _creds_data = yaml.safe_load(result.stdout.decode('utf8'))
         _merge_if_set(creds_data, _normalize_creds(_creds_data))
     except FileNotFoundError:
         pass  # juju trust not available
@@ -116,15 +116,14 @@ def _normalize_creds(creds_data):
     ca_cert = None
     # seems like this might have changed at some point;
     # newer controllers return the latter
-    trust_ca_keys = {'ca-certificates', 'cacertificates'}
-    if trust_ca_keys & creds_data.keys():
+    trust_ca_key = {'ca-certificates', 'cacertificates'} & creds_data.keys()
+    if trust_ca_key:
         # see K8s commit e3c8a0ceb66816433b095c4d734663e1b1e0e4ea
         # K8s in-tree cloud provider code is not flexible enough
         # to accept multiple certs that could be provided by Juju
         # so we can grab the first one only and hope it is the
         # right one
-        trust_ca_key = (trust_ca_keys & creds_data.keys()).pop()
-        ca_certificates = creds_data[trust_ca_key]
+        ca_certificates = creds_data[trust_ca_key.pop()]
         if ca_certificates:
             ca_cert = ca_certificates[0]
     elif 'endpoint-tls-ca' in creds_data:

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -14,7 +14,15 @@ from charms.reactive.relations import endpoint_from_name
 from charms import layer
 
 
-@when_any('config.changed.credentials')
+@when_any('config.changed.credentials',
+          'config.changed.auth-url',
+          'config.changed.username',
+          'config.changed.password',
+          'config.changed.project-name',
+          'config.changed.user-domain-name',
+          'config.changed.project-domain-name',
+          'config.changed.region',
+          'config.changed.endpoint-tls-ca')
 def update_creds():
     clear_flag('charm.openstack.creds.set')
 


### PR DESCRIPTION
Allow combined and individual config options to override any or all creds received from `juju trust`, and allow individual config options to override combined creds config.  This allows the operator to provide fields that might be missing from the main source, for whatever reason (such as the CA cert missing from the Juju trust data).

Fixes [lp:1822909](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1822909)