### PR TITLE
Detect Octavia and report over the relation

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -2,7 +2,12 @@ repo: 'https://github.com/juju-solutions/charm-openstack-integrator'
 includes:
   - 'layer:basic'
   - 'layer:status'
+  - 'layer:snap'
   - 'interface:openstack-integration'
 options:
   basic:
     use_venv: true
+  snap:
+    openstackclients:
+      channel: stable
+      classic: true

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -119,15 +119,8 @@ def detect_octavia():
         ),
     )
     try:
-        # This will attempt to create the proxy to the load-balancer service.
-        # Doing it this way, rather than using list_services(), handles older
-        # Neutron / Octavia implementations that have an inaccessible discovery
-        # document.
-        client.load_balancer
-    except openstack.exceptions.EndpointNotFound:
-        return False  # the Octavia endpoint was not found
-    else:
-        return True  # found the Octavia endpoint
+        services = {s['name'] for s in client.service_catalog}
+        return 'octavia' in services
     finally:
         try:
             client.close()  # try to be a good citizen

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -186,6 +186,7 @@ def _load_creds():
 def _run_with_creds(*args):
     creds = _load_creds()
     env = {
+        'PATH': os.pathsep.join(['/snap/bin', os.environ['PATH']]),
         'OS_AUTH_URL': creds['auth_url'],
         'OS_USERNAME': creds['username'],
         'OS_PASSWORD': creds['password'],
@@ -196,8 +197,8 @@ def _run_with_creds(*args):
         'OS_AUTH_VERSION': creds['version'],
         'OS_IDENTITY_API_VERSION': creds['version'],
     }
-    if creds['endpoint-tls-ca'] and not CA_CERT_FILE.exists():
-        ca_cert = b64decode(creds['endpoint-tls-ca'].encode('utf8'))
+    if creds['endpoint_tls_ca'] and not CA_CERT_FILE.exists():
+        ca_cert = b64decode(creds['endpoint_tls_ca'].encode('utf8'))
         CA_CERT_FILE.parent.mkdir(parents=True, exist_ok=True)
         CA_CERT_FILE.write_text(ca_cert + '\n')
     if CA_CERT_FILE.exists():

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -11,8 +11,6 @@ from charmhelpers.core.unitdata import kv
 
 from charms.layer import status
 
-import openstack
-
 
 # When debugging hooks, for some reason HOME is set to /home/ubuntu, whereas
 # during normal hook execution, it's /root. Set it here to be consistent.
@@ -52,34 +50,39 @@ def get_credentials():
     # pre-populate with empty values to avoid key and arg errors
     creds_data = {field: '' for field in required_fields + optional_fields}
 
-    # try to use Juju's trust feature
     try:
-        log('Checking credentials-get for credentials')
-        result = subprocess.run(['credential-get'],
-                                check=True,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        _creds_data = yaml.safe_load(result.stdout.decode('utf8'))
-        _merge_if_set(creds_data, _normalize_creds(_creds_data))
-    except FileNotFoundError:
-        pass  # juju trust not available
-    except subprocess.CalledProcessError as e:
-        if 'permission denied' not in e.stderr.decode('utf8'):
-            raise
-
-    # merge in combined credentials config
-    if config['credentials']:
+        # try to use Juju's trust feature
         try:
-            log('Using "credentials" config values for credentials')
-            _creds_data = b64decode(config['credentials']).decode('utf8')
-            _creds_data = json.loads(_creds_data)
+            log('Checking credentials-get for credentials')
+            result = subprocess.run(['credential-get'],
+                                    check=True,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+            _creds_data = yaml.safe_load(result.stdout.decode('utf8'))
             _merge_if_set(creds_data, _normalize_creds(_creds_data))
-        except Exception:
-            status.blocked('invalid value for credentials config')
-            return False
+        except FileNotFoundError:
+            pass  # juju trust not available
+        except subprocess.CalledProcessError as e:
+            if 'permission denied' not in e.stderr.decode('utf8'):
+                raise
 
-    # merge in individual config
-    _merge_if_set(creds_data, _normalize_creds(config))
+        # merge in combined credentials config
+        if config['credentials']:
+            try:
+                log('Using "credentials" config values for credentials')
+                _creds_data = b64decode(config['credentials']).decode('utf8')
+                _creds_data = json.loads(_creds_data)
+                _merge_if_set(creds_data, _normalize_creds(_creds_data))
+            except Exception:
+                status.blocked('invalid value for credentials config')
+                return False
+
+        # merge in individual config
+        _merge_if_set(creds_data, _normalize_creds(config))
+    except ValueError as e:
+        if str(e).startswith('unsupported auth-type'):
+            status.blocked(str(e))
+            return False
 
     if all(creds_data[k] for k in required_fields):
         _save_creds(creds_data)
@@ -101,31 +104,8 @@ def detect_octavia():
 
     Returns True if Octavia is found, and False otherwise.
     """
-    creds = get_user_credentials()
-    if creds['endpoint-tls-ca'] and not CA_CERT_FILE.exists():
-        ca_cert = b64decode(creds['endpoint-tls-ca'].encode('utf8'))
-        CA_CERT_FILE.parent.mkdir(parents=True, exist_ok=True)
-        CA_CERT_FILE.write_text(ca_cert + '\n')
-    client = openstack.connection.Connection(
-        region=creds['region'],
-        cacert=CA_CERT_FILE if CA_CERT_FILE.exists() else None,
-        auth=dict(
-            auth_url=creds['auth_url'],
-            username=creds['username'],
-            password=creds['password'],
-            project_name=creds['project_name'],
-            project_domain_name=creds['project_domain_name'],
-            user_domain_name=creds['user_domain_name'],
-        ),
-    )
-    try:
-        services = {s['name'] for s in client.service_catalog}
-        return 'octavia' in services
-    finally:
-        try:
-            client.close()  # try to be a good citizen
-        except AttributeError:
-            pass  # but allow for bug in openstacksdk
+    catalog = {s['Name'] for s in _openstack('catalog', 'list')}
+    return 'octavia' in catalog
 
 
 def cleanup():
@@ -150,6 +130,10 @@ def _normalize_creds(creds_data):
         attrs = creds_data
         endpoint = attrs['auth-url']
         region = attrs['region']
+
+    if attrs.get('auth-type') not in ('userpass', None):
+        raise ValueError('unsupported auth-type in credentials: '
+                         '{}'.format(attrs.get('auth-type')))
 
     ca_cert = None
     # seems like this might have changed at some point;
@@ -187,6 +171,7 @@ def _normalize_creds(creds_data):
         project_domain_name=attrs['project-domain-name'],
         project_name=attrs.get('project-name', attrs.get('tenant-name')),
         endpoint_tls_ca=ca_cert,
+        version=attrs.get('version'),
     )
 
 
@@ -196,3 +181,36 @@ def _save_creds(creds_data):
 
 def _load_creds():
     return kv().get('charm.openstack.full-creds')
+
+
+def _run_with_creds(*args):
+    creds = _load_creds()
+    env = {
+        'OS_AUTH_URL': creds['auth_url'],
+        'OS_USERNAME': creds['username'],
+        'OS_PASSWORD': creds['password'],
+        'OS_REGION_NAME': creds['region'],
+        'OS_USER_DOMAIN_NAME': creds['user_domain_name'],
+        'OS_PROJECT_NAME': creds['project_name'],
+        'OS_PROJECT_DOMAIN_NAME': creds['project_domain_name'],
+        'OS_AUTH_VERSION': creds['version'],
+        'OS_IDENTITY_API_VERSION': creds['version'],
+    }
+    if creds['endpoint-tls-ca'] and not CA_CERT_FILE.exists():
+        ca_cert = b64decode(creds['endpoint-tls-ca'].encode('utf8'))
+        CA_CERT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CA_CERT_FILE.write_text(ca_cert + '\n')
+    if CA_CERT_FILE.exists():
+        env['OS_CACERT'] = str(CA_CERT_FILE)
+
+    result = subprocess.run(args,
+                            env=env,
+                            check=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    return result.stdout.decode('utf8')
+
+
+def _openstack(*args):
+    output = _run_with_creds('openstack', *args, '--format=yaml')
+    return yaml.safe_load(output)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,3 +14,8 @@ tags: ['openstack', 'native', 'integration']
 provides:
   clients:
     interface: openstack-integration
+resources:
+  openstackclients:
+    type: file
+    filename: openstackclients.snap
+    description: Resource to side-load openstackclients snap in network-restricted deployments.

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,1 @@
+openstacksdk

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,0 @@
-openstacksdk


### PR DESCRIPTION
This adds detection for whether Octavia is actually available in the underlying OpenStack and reports that over the relation.

Depends on: https://github.com/juju-solutions/interface-openstack-integration/pull/11

Tested on serverstack (non-Octavia) and confirmed the flag is not included.  Still working on getting an Octavia-enabled OpenStack up for testing.