### PR TITLE
Handle cached creds not containing version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -81,10 +81,10 @@ options:
     default: false
   bs-version:
     description: |
-      Used to override automatic version detection. Valid values are v1, v2, v3
-      and auto. When auto is specified automatic detection will select the
-      highest supported version exposed by the underlying OpenStack cloud. If
-      not set, will use the upstream default.
+      Used to override automatic version detection for block storage usage.
+      Valid values are v1, v2, v3 and auto. When auto is specified automatic
+      detection will select the highest supported version exposed by the
+      underlying OpenStack cloud. If not set, will use the upstream default.
     type: string
     default: null
   trust-device-path:

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -194,9 +194,14 @@ def _run_with_creds(*args):
         'OS_USER_DOMAIN_NAME': creds['user_domain_name'],
         'OS_PROJECT_NAME': creds['project_name'],
         'OS_PROJECT_DOMAIN_NAME': creds['project_domain_name'],
-        'OS_AUTH_VERSION': creds['version'],
-        'OS_IDENTITY_API_VERSION': creds['version'],
     }
+    if creds.get('version'):
+        # version should always be added by _normalize_creds, but it might
+        # be empty in which case we shouldn't set the env vars
+        env.update({
+            'OS_IDENTITY_API_VERSION': creds['version'],
+            'OS_AUTH_VERSION': creds['version'],
+        })
     if creds['endpoint_tls_ca'] and not CA_CERT_FILE.exists():
         ca_cert = b64decode(creds['endpoint_tls_ca'].encode('utf8'))
         CA_CERT_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -42,6 +42,13 @@ def update_creds():
     clear_flag('charm.openstack.creds.set')
 
 
+@hook('upgrade-charm')
+def upgrade_charm():
+    # when the charm is upgraded, recheck the creds in case anything
+    # has changed or we want to handle any of the fields differently
+    clear_flag('charm.openstack.creds.set')
+
+
 @when_not('charm.openstack.creds.set')
 def get_creds():
     toggle_flag('charm.openstack.creds.set', layer.openstack.get_credentials())


### PR DESCRIPTION
We previously ignored the version from the creds (if available), but #18 added handling for that.  The cached creds from before the upgrade did not contain it and caused a KeyError.

Also updated the description of `bs-version` to call out that it is specifically a block storage setting, rather than an override for the API version generally.

Fixes [lp:1841271](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1841271)