### PR TITLE
Add loadbalancer endpoint support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,30 +53,60 @@ options:
       as a config option in a Juju CLI invocation.
     type: string
     default: ""
+  lb-subnet:
+    description: |
+      Override the subnet (name or ID) in which this charm will create load
+      balancers for other charms related on the loadbalancer endpoint. If not
+      set, the subnet over which the requesting application is related will be
+      used.
+    type: string
+    default: ""
+  lb-floating-network:
+    description: |
+      If set, this charm will assign a floating IP in this network (name or ID)
+      for load balancers created for other charms related on the loadbalancer
+      endpoint.
+    type: string
+    default: ""
+  lb-port:
+    description: |
+      Port to use for load balancers created by this charm for other charms
+      related on the loadbalancer endpoint.
+    type: int
+    default: 443
   subnet-id:
     description: |
-      Subnet ID from OpenStack that will be used to setup Load Balancers. Flag
-      LoadBalancer becomes active on cloud.conf file only if this config is set.
+      If set, it will be passed to integrated workloads to indicate in what
+      subnet load balancers should be created. For example, this will determine
+      what subnet Kubernetes uses for LoadBalancer type services in the
+      cluster.
     type: string
     default: ""
   floating-network-id:
     description: |
-      Floating IP network ID that should be used to set FIPs for load balancers.
+      If set, it will be passed to integrated workloads to indicate that
+      floating IPs should be created in the given network for load balancers
+      that those workloads manage. For example, this will determine whether and
+      where FIPs will be created by Kubernetes for LoadBalancer type services
+      in the cluster.
     type: string
     default: ""
   lb-method:
     description: |
-      Specifies an algorithm load balancer, that should be one between ROUND_ROBIN,
-      LEAST_CONNECTIONS, SOURCE_IP.
+      Algorithm that will be used by load balancers, which must be one of:
+      ROUND_ROBIN, LEAST_CONNECTIONS, SOURCE_IP. This applies both to load
+      balancers managed by this charm for applications related via the
+      loadbalancer endpoint, as well as to load balancers managed by integrated
+      workloads, such as Kubernetes.
     type: string
-    default: ""
+    default: "ROUND_ROBIN"
   manage-security-groups:
     description: |
-      Whether or not the Load Balancer should automatically manage security groups rule.
-      In case it is set to false, Load Balancer rules will be added to project (tenant)
-      default security-group. In case it is set to true, a new security-group will be
-      created for each Load Balancer, as well as its corresponding rules.
-      It is advised to set appropriate number of security-groups and rules.
+      Whether or not each load balancer should have its own security group, or
+      if all load balancers should use the default security group for the
+      project.  This applies both to load balancers managed by this charm for
+      applications related via the loadbalancer endpoint, as well as to load
+      balancers managed by integrated workloads, such as Kubernetes.
     type: boolean
     default: false
   bs-version:

--- a/layer.yaml
+++ b/layer.yaml
@@ -4,6 +4,8 @@ includes:
   - 'layer:status'
   - 'layer:snap'
   - 'interface:openstack-integration'
+  - 'interface:public-address'
+  - 'interface:http'
 options:
   basic:
     use_venv: true

--- a/layer.yaml
+++ b/layer.yaml
@@ -5,7 +5,6 @@ includes:
   - 'layer:snap'
   - 'interface:openstack-integration'
   - 'interface:public-address'
-  - 'interface:http'
 options:
   basic:
     use_venv: true

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -121,8 +121,6 @@ def detect_octavia():
 
 
 def manage_loadbalancer(app_name, members):
-    if not members:
-        return
     log('Managing load balancer for {}', app_name)
     subnet = config['lb-subnet'] or _default_subnet(members)
     fip_net = config['lb-floating-network']

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -2,7 +2,9 @@ import json
 import re
 import os
 import subprocess
+import time
 from base64 import b64decode, b64encode
+from ipaddress import ip_address, ip_network
 from pathlib import Path
 from traceback import format_exc
 from urllib.request import urlopen
@@ -20,6 +22,9 @@ from charms.layer import status
 os.environ['HOME'] = '/root'
 
 CA_CERT_FILE = Path('/etc/openstack-integrator/ca.crt')
+MODEL_UUID = os.environ['JUJU_MODEL_UUID']
+MODEL_SHORT_ID = MODEL_UUID.split('-')[-1]
+config = hookenv.config()
 
 
 def log(msg, *args):
@@ -110,13 +115,53 @@ def detect_octavia():
     try:
         catalog = {s['Name'] for s in _openstack('catalog', 'list')}
     except Exception:
-        log_err('Error while trying to detect Octavia', format_exc())
+        log_err('Error while trying to detect Octavia\n{}', format_exc())
         return None
     return 'octavia' in catalog
 
 
+def manage_loadbalancer(app_name, members):
+    if not members:
+        return
+    log('Managing load balancer for {}', app_name)
+    subnet = config['lb-subnet'] or _default_subnet(members)
+    fip_net = config['lb-floating-network']
+    port = str(config['lb-port'])
+    lb_algorithm = config['lb-method']
+    manage_secgrps = config['manage-security-groups']
+    lb = LoadBalancer.get_or_create(app_name,
+                                    port,
+                                    subnet,
+                                    lb_algorithm,
+                                    fip_net,
+                                    manage_secgrps)
+    lb.update_members(members)
+    return lb
+
+
 def cleanup():
+    # note: we don't bother cleaning up the SG because it's a singleton
+    # and can be reused in other / future deployments
+    for lb in LoadBalancer.get_all():
+        try:
+            lb.delete()
+        except OpenStackLBError:
+            # we're dying anyway, so we can't report this, but maybe we can
+            # delete the rest
+            pass
+
+
+class OpenStackError(Exception):
     pass
+
+
+class OpenStackLBError(OpenStackError):
+    def __init__(self, action, exc=True):
+        action = action[:-1]+'ing'
+        if exc:
+            log_err('Error {} loadbalancer\n{}', action, format_exc())
+        super().__init__('Error while {} load balancer; '
+                         'check credential and debug-log'.format(action))
 
 
 # Internal helpers
@@ -225,6 +270,11 @@ def _openstack(*args):
     return yaml.safe_load(output)
 
 
+def _neutron(*args):
+    output = _run_with_creds('neutron', *args, '--format=yaml')
+    return yaml.safe_load(output)
+
+
 def _determine_version(attrs, endpoint):
     if attrs.get('version'):
         return str(attrs['version'])
@@ -240,3 +290,505 @@ def _determine_version(attrs, endpoint):
         except (json.JSONDecodeError, UnicodeDecodeError, KeyError) as e:
             log_err('Failed to determine API version: {}', e)
             return None
+
+
+def _default_subnet(members):
+    """
+    Find the subnet which contains the given address.
+    """
+    address, _ = members[0]
+    address = ip_address(address)
+    for subnet_info in _openstack('subnet', 'list'):
+        subnet = ip_network(subnet_info['Subnet'])
+        if address in subnet:
+            return subnet_info['Name']
+    else:
+        log_err('Unable to find subnet for {}', address)
+        raise OpenStackLBError(action='create', exc=False)
+
+
+class LoadBalancer:
+    """
+    Base class for wrapper around the OpenStack CLI.
+    """
+    octavia_available = None
+
+    @classmethod
+    def get_or_create(cls, app_name, port, subnet, algorithm, fip_net,
+                      manage_secgrps):
+        """
+        Create a client instance for the given LB.
+
+        Returns the proper subclass depending on whether Octavia is available.
+        """
+        lb = cls(app_name, port, subnet, algorithm, fip_net, manage_secgrps)
+        if not lb.is_created:
+            try:
+                lb.create()
+            except subprocess.CalledProcessError:
+                raise OpenStackLBError(action='create')
+        return lb
+
+    def __init__(self, app_name, port, subnet, algorithm, fip_net,
+                 manage_secgrps):
+        self.name = 'openstack-integrator-{}-{}'.format(MODEL_SHORT_ID,
+                                                        app_name)
+        self.port = port
+        self.subnet = subnet
+        self.algorithm = algorithm
+        self.fip_net = fip_net
+        self.manage_secgrps = manage_secgrps
+        self._key = 'created_lbs.{}'.format(self.name)
+        self.sg_id = None
+        self.fip = None
+        self.address = None
+        self.members = set()
+        self.is_created = False
+        self._try_load_cached_info()
+        self._impl = self._get_impl()
+
+    def _get_impl(self):
+        cls = type(self)
+        if cls.octavia_available is None:
+            cls.octavia_available = detect_octavia()
+        if cls.octavia_available:
+            return OctaviaLBImpl(self.name,
+                                 self.port,
+                                 self.subnet,
+                                 self.algorithm,
+                                 self.fip_net,
+                                 self.manage_secgrps)
+        else:
+            return NeutronLBImpl(self.name,
+                                 self.port,
+                                 self.subnet,
+                                 self.algorithm,
+                                 self.fip_net,
+                                 self.manage_secgrps)
+
+    def create(self):
+        """
+        Create this loadbalancer for the first time.
+        """
+        # we may have a partially created LB, so we need to check
+        # whether we successfully got past creating the LB itself, or
+        # even if the partial-LB was manually cleaned up by the operator
+        lb_info = self._find('load balancers',
+                             self._impl.list_loadbalancers())
+        if lb_info:
+            # list doesn't contain all of the info we need
+            lb_info = self._impl.show_loadbalancer()
+            log('Found existing load balancer {} ({})',
+                self.name, lb_info['id'])
+        else:
+            lb_info = self._impl.create_loadbalancer()
+            log('Created load balancer {} ({})', self.name, lb_info['id'])
+            self._wait_lb_not_pending()
+        self.address = lb_info['vip_address']
+
+        if self.manage_secgrps:
+            sg_id = self._impl.find_secgrp(self.name)
+            if sg_id:
+                log('Found existing security group {} ({})', self.name, sg_id)
+            else:
+                sg_id = self._impl.create_secgrp(self.name)
+                log('Created security group {} ({})', self.name, sg_id)
+            self.sg_id = sg_id
+            if self._impl.get_port_sec_enabled():
+                self._impl.set_port_secgrp(lb_info['vip_port_id'], sg_id)
+                log('Added security group {} ({}) to port {}',
+                    self.name, sg_id, lb_info['vip_port_id'])
+                self._wait_lb_not_pending()
+        else:
+            sg_id = self._impl.find_secgrp('default')
+            if not sg_id:
+                log_err('Unable to find default security group')
+                raise OpenStackLBError(action='create', exc=False)
+            log('Using default security group ({})', sg_id)
+        if not self._find_matching_sg_rule(sg_id):
+            self._impl.create_sg_rule(sg_id, self.address)
+            log('Added rule for {}:{} to security group {} ({})',
+                self.address, self.port, self.name, sg_id)
+        else:
+            log('Found matching rule for {}:{} on security group {} ({})',
+                self.address, self.port, self.name, sg_id)
+
+        if not self._find('listeners', self._impl.list_listeners()):
+            self._impl.create_listener()
+            log('Created listener for {}:{}', self.address, self.port)
+            self._wait_lb_not_pending()
+        else:
+            log('Found existing listener for {}:{}', self.address, self.port)
+
+        if not self._find('pools', self._impl.list_pools()):
+            self._impl.create_pool()
+            log('Created pool {} using {}', self.name, self.algorithm)
+            self._wait_lb_not_pending()
+            self._wait_pool_not_pending()
+        else:
+            log('Found existing pool {}', self.name)
+
+        if self.fip_net:
+            for fip in self._impl.list_fips():
+                # why are these keys so inconsistent? :(
+                if fip['Fixed IP Address'] == self.address:
+                    self.fip = fip['Floating IP Address']
+                    log('Found existing FIP for {} -> {}',
+                        self.fip, self.address)
+                    break
+            else:
+                self.fip = self._impl.create_fip(self.address,
+                                                 lb_info['vip_port_id'])
+                log('Created FIP for {} -> {}', self.fip, self.address)
+
+        self.members = self._impl.list_members()
+        if self.members:
+            log('Found existing members: {}', self.members)
+
+        self._update_cached_info()
+        self.is_created = True
+
+    def _wait_not_pending(self, show_func):
+        for retry in range(30):
+            lb_status = show_func()['provisioning_status']
+            if not lb_status.startswith('PENDING_'):
+                break
+            time.sleep(2)
+        if lb_status != 'ACTIVE':
+            log_err('Invalid status when creating load balancer {}: {}',
+                    self.name, lb_status)
+            raise OpenStackLBError(action=('update' if self.is_created else
+                                           'create'), exc=False)
+
+    def _wait_lb_not_pending(self):
+        self._wait_not_pending(self._impl.show_loadbalancer)
+
+    def _wait_pool_not_pending(self):
+        if not isinstance(self._impl, NeutronLBImpl):
+            self._wait_not_pending(self._impl.show_pool)
+
+    def _find_matching_sg_rule(self, sg_id):
+        address = ip_address(self.address)
+        port = int(self.port)
+        for rule in self._impl.list_sg_rules(sg_id):
+            if rule['Port Range']:
+                port_min, port_max = rule['Port Range'].split(':')
+                port_match = int(port_min) <= int(port) <= int(port_max)
+            else:
+                port_match = True
+            ip_match = address in ip_network(rule['IP Range'] or '0.0.0.0/0')
+            if port_match and ip_match:
+                return True
+        return False
+
+    def _find(self, description, items):
+        """
+        Find the single item from the list whose 'name' field matches our
+        name.  The description is used for the error message.
+        """
+        results = []
+        for item in items:
+            if item['name'] == self.name:
+                results.append(item)
+        if len(results) > 1:
+            log_err('Multiple {} found: {}', description, self.name)
+            raise OpenStackLBError(action='create', exc=False)
+        return results[0] if results else None
+
+    def update_members(self, members):
+        """
+        Add or remove members to the load balancer to match the given set.
+        """
+        members = set(members)
+        if self.members == members:
+            return
+
+        try:
+            removed_members = self.members - members
+            for member in removed_members:
+                self._impl.delete_member(member)
+                log('Removed member: {}', member)
+                self._wait_pool_not_pending()
+
+            added_members = members - self.members
+            for member in added_members:
+                self._impl.create_member(member)
+                log('Added member: {}', member)
+                self._wait_pool_not_pending()
+        except subprocess.CalledProcessError:
+            raise OpenStackLBError(action='update')
+
+        self.members = members
+        self._update_cached_info()
+
+    def delete(self):
+        """
+        Delete this loadbalancer and all of its resources.
+        """
+        try:
+            # this would be easier if we could rely on --cascade,
+            # but it's not available with neutron
+            if self.fip:
+                self._impl.delete_fip()
+            for member in self.members:
+                self._impl.delete_member(member)
+            self._impl.delete_pool()
+            self._impl.delete_listener()
+            if self.sg_id:
+                self._impl.delete_secgrp()
+            self._impl.delete_loadbalancer()
+        except subprocess.CalledProcessError:
+            raise OpenStackLBError(action='delete')
+
+    def _try_load_cached_info(self):
+        info = kv().get(self._key)
+        if info:
+            self.sg_id = info['sg_id']
+            self.fip = info['fip']
+            self.address = info['address']
+            self.members = {tuple(m) for m in info['members']}
+            self.is_created = True
+
+    def _update_cached_info(self):
+        kv().set(self._key, {
+            'sg_id': self.sg_id,
+            'fip': self.fip,
+            'address': self.address,
+            'members': list(self.members),
+        })
+
+
+class BaseLBImpl:
+    def __init__(self, name, port, subnet, algorithm, fip_net, manage_secgrps):
+        self.name = name
+        self.port = port
+        self.subnet = subnet
+        self.algorithm = algorithm
+        self.fip_net = fip_net
+        self.manage_secgrps = manage_secgrps
+        self._project_id = kv().get('project_id')
+
+    @property
+    def project_id(self):
+        if not self._project_id:
+            creds = _load_creds()
+            project = creds['project_name']
+            project_domain = creds['project_domain_name']
+            self._project_id = _openstack('project', 'show',
+                                          '--domain', project_domain,
+                                          project)['id']
+            kv().set('project_id', self._project_id)
+        return self._project_id
+
+    def find_secgrp(self, name):
+        secgrps = {sg['Name']: sg
+                   for sg in _openstack('security', 'group', 'list',
+                                        '--project', self.project_id)}
+        return secgrps.get(name, {}).get('ID')
+
+    def create_secgrp(self, name):
+        sg_info = _openstack('security', 'group', 'create', name)
+        return sg_info['id']
+
+    def delete_secgrp(self, sg_id):
+        _openstack('security', 'group', 'delete', sg_id)
+
+    def list_sg_rules(self, sg_id):
+        return _openstack('security', 'group', 'rule', 'list',
+                          sg_id, '--ingress', '--protocol=tcp')
+
+    def create_sg_rule(self, sg_id, address):
+        _openstack('security', 'group', 'rule', 'create',
+                   '--ingress',
+                   '--protocol', 'tcp',
+                   '--remote-ip', address,
+                   '--dst-port', self.port,
+                   sg_id)
+
+    def get_port_sec_enabled(self):
+        subnet_info = _openstack('subnet', 'show', self.subnet)
+        network_info = _openstack('network', 'show', subnet_info['network_id'])
+        return network_info['port_security_enabled']
+
+    def set_port_secgrp(self, port_id, sg_id):
+        _openstack('port', 'set', '--security-group', sg_id, port_id)
+
+    def list_fips(self):
+        return _openstack('floating', 'ip', 'list')
+
+    def create_fip(self, address, port_id):
+        fip = _openstack('floating', 'ip', 'create',
+                         '--fixed-ip-address', address,
+                         '--port', port_id,
+                         self.fip_net)
+        return fip['floating_ip_address']
+
+    def delete_fip(self, fip):
+        _openstack('floating', 'ip', 'delete', fip)
+
+    def list_loadbalancers(self):
+        raise NotImplementedError()
+
+    def create_loadbalancer(self):
+        raise NotImplementedError()
+
+    def show_loadbalancer(self):
+        raise NotImplementedError()
+
+    def list_listeners(self):
+        raise NotImplementedError()
+
+    def create_listener(self):
+        raise NotImplementedError()
+
+    def delete_listener(self):
+        raise NotImplementedError()
+
+    def list_pools(self):
+        raise NotImplementedError()
+
+    def show_pool(self):
+        raise NotImplementedError()
+
+    def create_pool(self):
+        raise NotImplementedError()
+
+    def delete_pool(self):
+        raise NotImplementedError()
+
+    def list_members(self):
+        raise NotImplementedError()
+
+    def create_member(self, member):
+        raise NotImplementedError()
+
+    def delete_member(self, member):
+        raise NotImplementedError()
+
+
+class OctaviaLBImpl(BaseLBImpl):
+    """
+    Subclass with implementations specific to Octavia-enabled clouds.
+    """
+    def list_loadbalancers(self):
+        return _openstack('loadbalancer', 'list')
+
+    def create_loadbalancer(self):
+        return _openstack('loadbalancer', 'create',
+                          '--name', self.name,
+                          '--vip-subnet-id', self.subnet)
+
+    def show_loadbalancer(self):
+        return _openstack('loadbalancer', 'show', self.name)
+
+    def list_listeners(self):
+        return _openstack('loadbalancer', 'listener', 'list')
+
+    def create_listener(self):
+        return _openstack('loadbalancer', 'listener', 'create',
+                          '--name', self.name,
+                          '--protocol', 'HTTPS',
+                          '--protocol-port', self.port,
+                          self.name)
+
+    def delete_listener(self):
+        _openstack('loadbalancer', 'listener', 'delete', self.name)
+
+    def list_pools(self):
+        return _openstack('loadbalancer', 'pool', 'list')
+
+    def show_pool(self):
+        return _openstack('loadbalancer', 'pool', 'show', self.name)
+
+    def create_pool(self):
+        return _openstack('loadbalancer', 'pool', 'create',
+                          '--name', self.name,
+                          '--listener', self.name,
+                          '--lb-algorithm', self.algorithm,
+                          '--protocol', 'HTTPS')
+
+    def delete_pool(self):
+        _openstack('loadbalancer', 'pool', 'delete', self.name)
+
+    def list_members(self):
+        return {(m['address'], m['protocol_port'])
+                for m in _openstack('loadbalancer', 'member',
+                                    'list', self.name)}
+
+    def create_member(self, member):
+        addr, port = member
+        _openstack('loadbalancer', 'member', 'create',
+                   '--name', addr,
+                   '--address', addr,
+                   '--protocol-port', port,
+                   '--subnet-id', self.subnet,
+                   self.name)
+
+    def delete_member(self, member):
+        addr, _ = member
+        # nb: can't use _openstack() because member delete appears to be the
+        # only command that doesn't support --format=yaml
+        _run_with_creds('openstack', 'loadbalancer',
+                        'member', 'delete', self.name, addr)
+
+
+class NeutronLBImpl(BaseLBImpl):
+    """
+    Subclass with implementations specific to non-Octavia-enabled clouds.
+    """
+    def list_loadbalancers(self):
+        return _neutron('lbaas-loadbalancer-list')
+
+    def create_loadbalancer(self):
+        return _neutron('lbaas-loadbalancer-create',
+                        '--name', self.name,
+                        self.subnet)
+
+    def show_loadbalancer(self):
+        return _neutron('lbaas-loadbalancer-show', self.name)
+
+    def list_listeners(self):
+        return _neutron('lbaas-listener-list')
+
+    def create_listener(self):
+        return _neutron('lbaas-listener-create',
+                        '--name', self.name,
+                        '--protocol', 'HTTPS',
+                        '--protocol-port', self.port,
+                        '--loadbalancer', self.name)
+
+    def delete_listener(self):
+        _neutron('lbaas-listener-delete', self.name)
+
+    def list_pools(self):
+        return _neutron('lbaas-pool-list')
+
+    def show_pool(self):
+        return _neutron('lbaas-pool-show', self.name)
+
+    def create_pool(self):
+        return _neutron('lbaas-pool-create',
+                        '--name', self.name,
+                        '--listener', self.name,
+                        '--lb-algorithm', self.algorithm,
+                        '--protocol', 'HTTPS')
+
+    def delete_pool(self):
+        _neutron('lbaas-pool-delete', self.name)
+
+    def list_members(self):
+        return {(m['address'], m['protocol_port'])
+                for m in _neutron('lbaas-member-list', self.name)}
+
+    def create_member(self, member):
+        addr, port = member
+        _neutron('lbaas-member-create',
+                 '--name', addr,
+                 '--address', addr,
+                 '--protocol-port', port,
+                 '--subnet', self.subnet,
+                 self.name)
+
+    def delete_member(self, member):
+        addr, _ = member
+        _neutron('lbaas-member-delete', addr, self.name)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,6 +14,8 @@ tags: ['openstack', 'native', 'integration']
 provides:
   clients:
     interface: openstack-integration
+  loadbalancer:
+    interface: public-address
 resources:
   openstackclients:
     type: file

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -115,6 +115,8 @@ def create_or_update_loadbalancers():
     lb_clients = endpoint_from_name('loadbalancer')
     try:
         for request in lb_clients.requests:
+            if not request.members:
+                continue
             lb = layer.openstack.manage_loadbalancer(request.application_name,
                                                      request.members)
             request.set_address_port(lb.fip or lb.address, lb.port)

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -107,8 +107,7 @@ def handle_requests():
     clients.mark_completed()
 
 
-@when_all('charm.openstack.creds.set')
-@when_any('internal-lb-server.available',
+@when_all('charm.openstack.creds.set',
           'endpoint.loadbalancer.joined')
 def create_or_update_loadbalancers():
     layer.status.maintenance('Managing load balancers')

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -58,7 +58,7 @@ def get_creds():
           'charm.openstack.creds.set')
 @when_not('endpoint.clients.requests-pending')
 def no_requests():
-    layer.status.active('ready')
+    layer.status.active('Ready')
 
 
 @when_all('snap.installed.openstackclients',
@@ -67,6 +67,7 @@ def no_requests():
 @when_any('endpoint.clients.requests-pending',
           'config.changed')
 def handle_requests():
+    layer.status.maintenance('Granting integration requests')
     clients = endpoint_from_name('clients')
     config_change = is_flag_set('config.changed')
     config = hookenv.config()
@@ -76,7 +77,7 @@ def handle_requests():
         # use bool() to force True / False instead of 1 / 0
         manage_security_groups = bool(manage_security_groups)
     except ValueError:
-        layer.status.blocked('invalid value for manage-security-groups config')
+        layer.status.blocked('Invalid value for manage-security-groups config')
         return
     except AttributeError:
         # in case manage_security_groups is already bool
@@ -84,7 +85,7 @@ def handle_requests():
     requests = clients.all_requests if config_change else clients.new_requests
     for request in requests:
         layer.status.maintenance(
-            'granting request for {}'.format(request.unit_name))
+            'Granting request for {}'.format(request.unit_name))
         creds = layer.openstack.get_user_credentials()
         request.set_credentials(**creds)
         request.set_lbaas_config(config['subnet-id'],
@@ -106,15 +107,22 @@ def handle_requests():
     clients.mark_completed()
 
 
-@when_all('charm.openstack.creds.set',
+@when_all('charm.openstack.creds.set')
+@when_any('internal-lb-server.available',
           'endpoint.loadbalancer.joined')
 def create_or_update_loadbalancers():
-    clients = endpoint_from_name('loadbalancer')
-    for relation in clients.relations:
-        address, port = layer.openstack.create_or_update_loadbalancer(relation)
-        clients.set_address_port(address, port, relation)
+    layer.status.maintenance('Managing load balancers')
+    lb_clients = endpoint_from_name('loadbalancer')
+    try:
+        for request in lb_clients.requests:
+            lb = layer.openstack.manage_loadbalancer(request.application_name,
+                                                     request.members)
+            request.set_address_port(lb.fip or lb.address, lb.port)
+    except layer.openstack.OpenStackError as e:
+        layer.status.blocked(str(e))
 
 
 @hook('stop')
 def cleanup():
+    # TODO: Also clean up removed LBs as they go away
     layer.openstack.cleanup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from unittest.mock import MagicMock
 
@@ -7,3 +8,5 @@ sys.modules['charmhelpers'] = ch
 sys.modules['charmhelpers.core'] = ch.core
 sys.modules['charmhelpers.core.unitdata'] = ch.core.unitdata
 sys.modules['charms.layer.status'] = MagicMock()
+
+os.environ['JUJU_MODEL_UUID'] = 'test-1234'

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -4,6 +4,7 @@ import tempfile
 from base64 import b64encode
 from pathlib import Path
 from unittest import mock
+from subprocess import CalledProcessError
 
 from charms.layer import openstack
 
@@ -18,8 +19,17 @@ def patch_fixture(patch_target):
 
 urlopen = patch_fixture('charms.layer.openstack.urlopen')
 log_err = patch_fixture('charms.layer.openstack.log_err')
-load_creds = patch_fixture('charms.layer.openstack._load_creds')
+_load_creds = patch_fixture('charms.layer.openstack._load_creds')
+detect_octavia = patch_fixture('charms.layer.openstack.detect_octavia')
 run = patch_fixture('subprocess.run')
+_run_with_creds = patch_fixture('charms.layer.openstack._run_with_creds')
+_openstack = patch_fixture('charms.layer.openstack._openstack')
+_neutron = patch_fixture('charms.layer.openstack._neutron')
+LoadBalancerClient = patch_fixture('charms.layer.openstack.LoadBalancerClient')
+OctaviaLBClient = patch_fixture('charms.layer.openstack.OctaviaLBClient')
+NeutronLBClient = patch_fixture('charms.layer.openstack.NeutronLBClient')
+_default_subnet = patch_fixture('charms.layer.openstack._default_subnet')
+sleep = patch_fixture('time.sleep')
 
 
 @pytest.fixture
@@ -28,6 +38,25 @@ def cert_file():
         cert_file = Path(tmpdir) / 'test.crt'
         with mock.patch('charms.layer.openstack.CA_CERT_FILE', cert_file):
             yield cert_file
+
+
+@pytest.fixture
+def config():
+    with mock.patch('charms.layer.openstack.config', {}) as config:
+        yield config
+
+
+@pytest.fixture
+def impl():
+    with mock.patch.object(openstack.LoadBalancer, '_get_impl') as _get_impl:
+        _get_impl.return_value = mock.Mock(spec=openstack.BaseLBImpl)
+        yield _get_impl()
+
+
+@pytest.fixture
+def kv():
+    with mock.patch.object(openstack, 'kv') as kv:
+        yield kv()
 
 
 def test_determine_version(urlopen, log_err):
@@ -66,8 +95,8 @@ def _b64(s):
     return b64encode(s.encode('utf8')).decode('utf8')
 
 
-def test_run_with_creds(cert_file, load_creds, run):
-    load_creds.return_value = {
+def test_run_with_creds(cert_file, _load_creds, run):
+    _load_creds.return_value = {
         'auth_url': 'auth_url',
         'region': 'region',
         'username': 'username',
@@ -95,20 +124,242 @@ def test_run_with_creds(cert_file, load_creds, run):
         'OS_CACERT': str(cert_file),
     }, check=True, stdout=mock.ANY)
 
-    load_creds.return_value['endpoint_tls_ca'] = _b64('foo')
+    _load_creds.return_value['endpoint_tls_ca'] = _b64('foo')
     openstack._run_with_creds('my', 'args')
     assert cert_file.read_text() == 'foo\n'
 
-    load_creds.return_value['endpoint_tls_ca'] = None
-    del load_creds.return_value['version']
+    _load_creds.return_value['endpoint_tls_ca'] = None
+    del _load_creds.return_value['version']
     openstack._run_with_creds('my', 'args')
     env = run.call_args[1]['env']
     assert env['OS_CACERT'] == str(cert_file)
     assert 'OS_IDENTITY_API_VERSION' not in env
 
     cert_file.unlink()
-    load_creds.return_value['version'] = None
+    _load_creds.return_value['version'] = None
     openstack._run_with_creds('my', 'args')
     env = run.call_args[1]['env']
     assert 'OS_CACERT' not in env
     assert 'OS_IDENTITY_API_VERSION' not in env
+
+
+def test_default_subnet(_openstack):
+    members = [('192.168.0.1', 80), ('10.0.0.1', 80)]
+    _openstack.return_value = [
+        {'Name': 'a', 'Subnet': '192.168.0.0/24'},
+        {'Name': 'b', 'Subnet': '10.0.0.0/16'},
+    ]
+    assert openstack._default_subnet(members) == 'a'
+    assert openstack._default_subnet(list(reversed(members))) == 'b'
+    with pytest.raises(openstack.OpenStackLBError):
+        openstack._default_subnet([('10.1.0.1', 80)])
+
+
+def test_get_or_create(kv):
+    args = ('app', '80', 'subnet', 'alg', None, False)
+    with mock.patch.object(openstack.LoadBalancer, 'create') as create:
+        kv.get.return_value = {'sg_id': 'sg_id',
+                               'fip': 'fip',
+                               'address': 'address',
+                               'members': [[1, 2], [3, 4]]}
+        lb = openstack.LoadBalancer.get_or_create(*args)
+        assert not create.called
+        assert lb.name == 'openstack-integrator-1234-app'
+        assert lb.port == '80'
+        assert lb.subnet == 'subnet'
+        assert lb.algorithm == 'alg'
+        assert lb.fip_net is None
+        assert lb.manage_secgrps is False
+        assert lb._key == 'created_lbs.openstack-integrator-1234-app'
+        assert lb.sg_id == 'sg_id'
+        assert lb.fip == 'fip'
+        assert lb.address == 'address'
+        assert lb.members == {(1, 2), (3, 4)}
+        assert lb.is_created is True
+
+        kv.get.return_value = None
+        lb = openstack.LoadBalancer.get_or_create(*args)
+        assert create.called
+        assert lb.sg_id is None
+        assert lb.fip is None
+        assert lb.address is None
+        assert lb.members == set()
+
+        create.side_effect = CalledProcessError(1, 'cmd')
+        with pytest.raises(openstack.OpenStackLBError):
+            openstack.LoadBalancer.get_or_create(*args)
+
+
+def test_create_new(impl, sleep, log_err):
+    openstack.kv().get.return_value = None
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    assert not lb.is_created
+    lb.name = 'name'
+    impl.list_loadbalancers.return_value = []
+    impl.create_loadbalancer.return_value = {'id': '1234',
+                                             'vip_address': '1.1.1.1',
+                                             'vip_port_id': '4321'}
+    impl.show_loadbalancer.return_value = {'provisioning_status': 'ACTIVE'}
+    impl.show_pool.return_value = {'provisioning_status': 'ACTIVE'}
+    impl.find_secgrp.return_value = 'sg_id'
+    impl.list_listeners.return_value = []
+    impl.list_pools.return_value = []
+    impl.list_members.return_value = ['members']
+    impl.list_sg_rules.return_value = []
+    impl.get_port_sec_enabled.return_value = True
+    lb.create()
+    assert lb.sg_id is None
+    assert lb.fip is None
+    assert lb.address == '1.1.1.1'
+    assert lb.members == ['members']
+    assert lb.is_created
+    assert impl.create_loadbalancer.called
+    assert not impl.create_secgrp.called
+    impl.create_sg_rule.assert_called_with('sg_id', '1.1.1.1')
+    assert not impl.set_port_secgrp.called
+    assert impl.create_listener.called
+    assert impl.create_pool.called
+    assert not impl.list_fips.called
+    assert not impl.create_fip.called
+
+    impl.find_secgrp.return_value = None
+    with pytest.raises(openstack.OpenStackLBError):
+        lb.create()
+    log_err.assert_called_with('Unable to find default security group')
+
+    lb.fip_net = 'net'
+    lb.manage_secgrps = True
+    impl.create_secgrp.return_value = 'sg_id'
+    impl.list_fips.return_value = []
+    lb.create()
+    assert lb.sg_id == 'sg_id'
+    impl.create_secgrp.assert_called_with('name')
+    impl.set_port_secgrp.assert_called_with('4321', 'sg_id')
+    impl.create_fip.assert_called_with('1.1.1.1', '4321')
+
+
+def test_create_recover(impl, sleep):
+    openstack.kv().get.return_value = None
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', 'net', True)
+    lb.name = 'name'
+    impl.list_loadbalancers.return_value = [{'name': 'name'}]
+    impl.show_loadbalancer.return_value = {'id': '2345',
+                                           'provisioning_status': 'ACTIVE',
+                                           'vip_address': '1.1.1.1',
+                                           'vip_port_id': '4321'}
+    impl.find_secgrp.return_value = 'sg_id'
+    impl.list_sg_rules.return_value = [{'Port Range': '', 'IP Range': ''}]
+    impl.get_port_sec_enabled.return_value = False
+    impl.list_listeners.return_value = [{'name': 'name'}]
+    impl.list_pools.return_value = [{'name': 'name'}]
+    impl.list_fips.return_value = [
+        {'Fixed IP Address': '2.2.2.2', 'Floating IP Address': '3.3.3.3'},
+        {'Fixed IP Address': '1.1.1.1', 'Floating IP Address': '4.4.4.4'},
+    ]
+    impl.list_members.return_value = ['members']
+    lb.create()
+    assert lb.sg_id == 'sg_id'
+    assert lb.fip == '4.4.4.4'
+    assert lb.address == '1.1.1.1'
+    assert lb.members == ['members']
+    assert lb.is_created
+    assert not impl.create_loadbalancer.called
+    assert not impl.create_secgrp.called
+    assert not impl.create_listener.called
+    assert not impl.create_pool.called
+    assert not impl.create_fip.called
+
+
+def test_wait_not_pending(impl, sleep):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    test_func = mock.Mock(side_effect=[
+        {'provisioning_status': 'PENDING_CREATE'},
+        {'provisioning_status': 'PENDING_UPDATE'},
+        {'provisioning_status': 'PENDING_DELETE'},
+        {'provisioning_status': 'ACTIVE'},
+    ])
+    lb._wait_not_pending(test_func)
+    assert sleep.call_count == 3
+
+    test_func = mock.Mock(return_value={
+        'provisioning_status': 'PENDING_DELETE',
+    })
+    with pytest.raises(openstack.OpenStackLBError):
+        lb._wait_not_pending(test_func)
+
+
+def test_find_matching_sg_rule(impl):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    lb.address = '1.1.1.1'
+
+    impl.list_sg_rules.return_value = [{'Port Range': None,
+                                        'IP Range': None}]
+    assert lb._find_matching_sg_rule('sg_id')
+
+    impl.list_sg_rules.return_value = [{'Port Range': '60:90',
+                                        'IP Range': ''}]
+    assert lb._find_matching_sg_rule('sg_id')
+
+    impl.list_sg_rules.return_value = [{'Port Range': '',
+                                        'IP Range': '1.0.0.0/8'}]
+    assert lb._find_matching_sg_rule('sg_id')
+
+    impl.list_sg_rules.return_value = [{'Port Range': '81:90',
+                                        'IP Range': ''},
+                                       {'Port Range': '',
+                                        'IP Range': '2.0.0.0/8'}]
+    assert not lb._find_matching_sg_rule('sg_id')
+
+    impl.list_sg_rules.return_value = []
+    assert not lb._find_matching_sg_rule('sg_id')
+
+
+def test_find(impl, log_err):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    lb.name = 'lb'
+    item1 = {'id': 1, 'name': 'not-lb'}
+    item2 = {'id': 2, 'name': 'lb'}
+    item3 = {'id': 3, 'name': 'lb'}
+    assert lb._find('foo', [item1]) is None
+    assert lb._find('foo', [item1, item2]) == item2
+    with pytest.raises(openstack.OpenStackLBError):
+        lb._find('foo', [item1, item2, item3])
+    log_err.assert_called_with('Multiple {} found: {}', 'foo', 'lb')
+
+
+def test_update_members(impl):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    impl.show_pool.return_value = {'provisioning_status': 'ACTIVE'}
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(1, 2), (3, 4)})
+    assert not impl.delete_member.called
+    assert not impl.create_member.called
+
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(1, 2), (3, 4), (5, 6)})
+    assert not impl.delete_member.called
+    assert impl.create_member.called
+    assert lb.members == {(1, 2), (3, 4), (5, 6)}
+
+    impl.create_member.reset_mock()
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(1, 2)})
+    assert impl.delete_member.called
+    assert not impl.create_member.called
+
+    impl.delete_member.reset_mock()
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(5, 6)})
+    assert impl.delete_member.called
+    assert impl.create_member.called
+
+    impl.delete_member.side_effect = CalledProcessError(1, 'cmd')
+    lb.members = {(1, 2), (3, 4)}
+    with pytest.raises(openstack.OpenStackLBError):
+        lb.update_members(set())
+
+    impl.delete_member.side_effect = AssertionError('should not be called')
+    impl.create_member.side_effect = CalledProcessError(1, 'cmd')
+    lb.members = set()
+    with pytest.raises(openstack.OpenStackLBError):
+        lb.update_members({(1, 2)})


### PR DESCRIPTION
This adds the ability for the integrator charm to create load balancers for applications related to the loadbalancer relation endpoint.  This can be used, for example, by the Charmed Kubernetes bundle to replace the kubeapi-load-balancer charm with a native OpenStack load balancer.

Partially addresses: [lp:1836885](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1836885)
Depends on: https://github.com/juju-solutions/interface-public-address/pull/7