### PR TITLE
Change storageClassName to cdk-cinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
-  storageClassName: openstack-standard
+  storageClassName: cdk-cinder
 EOY
 
 # create the busybox pod with a volume using that PVC:


### PR DESCRIPTION
This PR changes storageClassName from openstack-standard to
cdk-cinder, which is the current name[1].

[1] https://github.com/charmed-kubernetes/cdk-addons/blob/master/bundled-templates/storageclass-openstack.yaml#L4