### PR TITLE
Improve handling and documentation of credentials config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,8 +3,8 @@ options:
     description: |
       The base64-encoded contents of a JSON file containing OpenStack credentials.
 
-      The credentials must contain the following keys: auth-url, username, password,
-      project-name, user-domain-name, and project-domain-name.
+      The credentials must contain the following keys: auth-url, region, username,
+      password, project-name, user-domain-name, and project-domain-name.
 
       It could also contain a base64-encoded CA certificate in endpoint-tls-ca key value.
 

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -192,8 +192,8 @@ def _merge_if_set(dst, src):
 def _normalize_creds(creds_data):
     if 'endpoint' in creds_data:
         endpoint = creds_data['endpoint']
-        region = creds_data['region']
-        attrs = creds_data['credential']['attributes']
+        region = creds_data.get('region', '')
+        attrs = creds_data.get('credential', {}).get('attributes', {})
     else:
         attrs = creds_data
         endpoint = attrs.get('auth-url', '')

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -1,3 +1,4 @@
+import binascii
 import json
 import re
 import os
@@ -81,8 +82,13 @@ def get_credentials():
                 _creds_data = b64decode(config['credentials']).decode('utf8')
                 _creds_data = json.loads(_creds_data)
                 _merge_if_set(creds_data, _normalize_creds(_creds_data))
-            except Exception as e:
-                if str(e).startswith('unsupported auth-type'):
+            except (ValueError,
+                    TypeError,
+                    binascii.Error,
+                    json.JSONDecodeError,
+                    UnicodeDecodeError) as e:
+                if isinstance(e, ValueError) and \
+                   str(e).startswith('unsupported auth-type'):
                     raise  # handled below
                 log_err('Invalid value for credentials config\n{}',
                         format_exc())

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -9,12 +9,13 @@ from unittest import mock
 import subprocess
 from urllib.request import urlopen
 from time import sleep
+import charms.layer
 
 from charms.unit_test import patch_fixture
-import charms.layer.openstack
 import reactive.openstack
 
 openstack = charms.layer.openstack
+status = charms.layer.status
 
 log_err = patch_fixture('charms.layer.openstack.log_err')
 _load_creds = patch_fixture('charms.layer.openstack._load_creds')
@@ -28,6 +29,9 @@ NeutronLBClient = patch_fixture('charms.layer.openstack.NeutronLBClient')
 _default_subnet = patch_fixture('charms.layer.openstack._default_subnet')
 kv = patch_fixture('charms.layer.openstack.kv')
 config = patch_fixture('charms.layer.openstack.config', {})
+_normalize_creds = patch_fixture('charms.layer.openstack._normalize_creds')
+_save_creds = patch_fixture('charms.layer.openstack._save_creds')
+_determine_version = patch_fixture('charms.layer.openstack._determine_version')
 
 
 class MockCalledProcessError(Exception):
@@ -74,6 +78,12 @@ def test_determine_version(log_err):
         b'"type": "application/vnd.openstack.identity-v3+json"}]}}')
     assert openstack._determine_version({}, 'https://endpoint/') == '3'
     assert not log_err.called
+
+    urlopen.side_effect = ValueError('foo')
+    assert openstack._determine_version({}, 'https://endpoint/') is None
+
+    urlopen.side_effect = None
+    assert openstack._determine_version({}, 'https://endpoint/') == '3'
 
     read.return_value = b'.'
     assert openstack._determine_version({}, 'https://endpoint/') is None
@@ -391,3 +401,175 @@ def test_series_upgrade():
     assert charms.layer.status.blocked.call_count == 0
     reactive.openstack.pre_series_upgrade()
     assert charms.layer.status.blocked.call_count == 1
+
+
+def test_get_credentials(_normalize_creds, _save_creds, log_err):
+    openstack.hookenv.config.return_value = config = {
+        'credentials': None,
+    }
+    subprocess.run.side_effect = MockCalledProcessError(1, b'foo')
+    with pytest.raises(MockCalledProcessError):
+        openstack.get_credentials()
+
+    subprocess.run.side_effect = MockCalledProcessError(1,
+                                                        b'permission denied')
+    _normalize_creds.side_effect = ValueError('unsupported auth-type')
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with('unsupported auth-type')
+
+    _normalize_creds.reset_mock()
+    status.blocked.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with('unsupported auth-type')
+    assert _normalize_creds.call_args_list == [
+        mock.call({'credentials': None}),
+    ]
+
+    status.blocked.reset_mock()
+    _normalize_creds.reset_mock()
+    _normalize_creds.side_effect = lambda a: a
+    stdout = b'{}'
+    subprocess.run.side_effect = lambda *a, **k: mock.Mock(stdout=stdout)
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with(
+        'missing credentials; grant with `juju trust` or set via config')
+    assert _normalize_creds.call_args_list == [
+        mock.call({}),
+        mock.call({'credentials': None}),
+    ]
+
+    _normalize_creds.reset_mock()
+    stdout = b'{"foo": "bar"}'
+    assert openstack.get_credentials() is False
+    assert _normalize_creds.call_args_list == [
+        mock.call({'foo': 'bar'}),
+        mock.call({'credentials': None}),
+    ]
+
+    status.blocked.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    config['credentials'] = 'foo'
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with(
+        'invalid value for credentials config: Incorrect padding')
+
+    status.blocked.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    config['credentials'] = 'ewo='
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with(
+        'invalid value for credentials config: Expecting property name '
+        'enclosed in double quotes: line 2 column 1 (char 2)')
+
+    _normalize_creds.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    config['credentials'] = 'eyJmb28iOiAiYmFyIn0K'
+    assert openstack.get_credentials() is False
+    assert _normalize_creds.call_args_list == [
+        mock.call({'foo': 'bar'}),
+        mock.call({'credentials': 'eyJmb28iOiAiYmFyIn0K'}),
+    ]
+
+    config.update({
+        'credentials': None,
+        'auth_url': 'auth-url',
+        'region': 'region',
+        'username': 'username',
+        'password': 'password',
+        'user_domain_name': 'user-domain-name',
+        'project_domain_name': 'project-domain-name',
+        'project_name': 'project-name',
+    })
+    expected = config.copy()
+    del expected['credentials']
+    expected['endpoint_tls_ca'] = ''
+    assert openstack.get_credentials() is True
+    _save_creds.assert_called_with(expected)
+
+    _save_creds.reset_mock()
+    status.blocked.reset_mock()
+    config['region'] = ''
+    assert openstack.get_credentials() is False
+    assert not _save_creds.called
+    status.blocked.assert_called_with('missing required credential: region')
+
+    status.blocked.reset_mock()
+    config['username'] = ''
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with('missing required credentials: '
+                                      'region, username')
+
+
+def test_normalize_creds(_determine_version, log_err):
+    _determine_version.return_value = '3'
+    with pytest.raises(ValueError) as excinfo:
+        openstack._normalize_creds({'auth-type': 'allow'})
+    assert str(excinfo.value) == 'unsupported auth-type in credentials: allow'
+    with pytest.raises(ValueError) as excinfo:
+        openstack._normalize_creds({
+            'endpoint': '/',
+            'credential': {
+                'attributes': {
+                    'auth-type': 'allow',
+                },
+            },
+        })
+    assert str(excinfo.value) == 'unsupported auth-type in credentials: allow'
+    assert openstack._normalize_creds({}) == dict(
+        auth_url='',
+        region='',
+        username=None,
+        password=None,
+        user_domain_name=None,
+        project_domain_name=None,
+        project_name=None,
+        endpoint_tls_ca=None,
+        version='3',
+    )
+    _determine_version.assert_called_with({}, '')
+    attrs = {
+        'auth-url': 'auth-url',
+        'region': 'us-east-1',
+        'username': 'username',
+        'password': 'password',
+        'user-domain-name': 'user-domain-name',
+        'project-domain-name': 'project-domain-name',
+        'tenant-name': 'tenant-name',
+    }
+    expected = dict(
+        auth_url='auth-url',
+        region='us-east-1',
+        username='username',
+        password='password',
+        user_domain_name='user-domain-name',
+        project_domain_name='project-domain-name',
+        project_name='tenant-name',
+        endpoint_tls_ca=None,
+        version='3',
+    )
+    assert openstack._normalize_creds(attrs) == expected
+    assert openstack._normalize_creds({
+        'endpoint': 'endpoint',
+        'region': 'region',
+        'credential': {'attributes': attrs},
+    }) == dict(expected, auth_url='endpoint', region='region')
+
+    attrs['project-name'] = expected['project_name'] = 'project-name'
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['ca-certificates'] = []
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['ca-certificates'] = ['ca-cert']
+    expected['endpoint_tls_ca'] = 'Y2EtY2VydA=='
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['ca-certificates'] = ['Y2EtY2VydA==']
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['cacertificates'] = attrs.pop('ca-certificates')
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['endpoint-tls-ca'] = attrs.pop('cacertificates')[0]
+    assert openstack._normalize_creds(attrs) == expected


### PR DESCRIPTION
Provide more info in the log and status message about what is wrong or missing from the credentials, and add region to the list of required fields in the config descripiton.

Fixes [lp:1889079](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1889079)
Fixes [lp:1867097](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1867097)
Fixes [lp:1835768](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1835768)