### PR TITLE
Expose keystone credentials relation

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -5,6 +5,7 @@ includes:
   - 'layer:snap'
   - 'interface:openstack-integration'
   - 'interface:public-address'
+  - 'interface:keystone-credentials'
 options:
   basic:
     use_venv: true

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -264,15 +264,6 @@ def get_creds_and_reformat():
     formatted_creds['auth_port'] = auth_url_parsed.port
     formatted_creds['credentials_port'] = auth_url_parsed.port
     formatted_creds['api_version'] = creds['version']
-    formatted_creds['credentials_username'] = creds['username']
-    formatted_creds['credentials_password'] = creds['password']
-    formatted_creds['credentials_project'] = creds['project_name']
-    formatted_creds['credentials_project_id'] = '1'
-    formatted_creds['credentials_user_domain_name'] = creds['user_domain_name']
-    formatted_creds['domain'] = creds['user_domain_name']
-    formatted_creds['credentials_project_domain_name'] = creds['project_domain_name']
-    formatted_creds['region'] = creds['region']
-    formatted_creds['endpoint_tls_ca'] = creds['endpoint_tls_ca']
     return formatted_creds
 
 

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -9,6 +9,7 @@ from ipaddress import ip_address, ip_network
 from pathlib import Path
 from traceback import format_exc
 from urllib.request import urlopen
+from urllib.parse import urlparse
 
 import yaml
 
@@ -249,6 +250,30 @@ def _normalize_creds(creds_data):
 
 def _save_creds(creds_data):
     kv().set('charm.openstack.full-creds', creds_data)
+
+
+def get_creds_and_reformat():
+    creds = _load_creds()
+    formatted_creds = {}
+    auth_url_parsed = urlparse(creds['auth_url'])
+
+    formatted_creds['auth_protocol'] = auth_url_parsed.scheme
+    formatted_creds['credentials_protocol'] = auth_url_parsed.scheme
+    formatted_creds['auth_host'] = auth_url_parsed.hostname
+    formatted_creds['credentials_host'] = auth_url_parsed.hostname
+    formatted_creds['auth_port'] = auth_url_parsed.port
+    formatted_creds['credentials_port'] = auth_url_parsed.port
+    formatted_creds['api_version'] = creds['version']
+    formatted_creds['credentials_username'] = creds['username']
+    formatted_creds['credentials_password'] = creds['password']
+    formatted_creds['credentials_project'] = creds['project_name']
+    formatted_creds['credentials_project_id'] = '1'
+    formatted_creds['credentials_user_domain_name'] = creds['user_domain_name']
+    formatted_creds['domain'] = creds['user_domain_name']
+    formatted_creds['credentials_project_domain_name'] = creds['project_domain_name']
+    formatted_creds['region'] = creds['region']
+    formatted_creds['endpoint_tls_ca'] = creds['endpoint_tls_ca']
+    return formatted_creds
 
 
 def _load_creds():

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,8 @@ tags: ['openstack', 'native', 'integration']
 provides:
   clients:
     interface: openstack-integration
+  credentials:
+    interface: keystone-credentials
   loadbalancer:
     interface: public-address
 resources:

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -113,6 +113,7 @@ def write_credentials():
     reformatted_creds = layer.openstack.get_creds_and_reformat()
     credentials.push_into_relation(reformatted_creds)
 
+
 @when_all('charm.openstack.creds.set',
           'endpoint.loadbalancer.joined')
 @when_not('upgrade.series.in-progress')

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -111,7 +111,7 @@ def handle_requests():
 def write_credentials():
     credentials = endpoint_from_name('credentials')
     reformatted_creds = layer.openstack.get_creds_and_reformat()
-    credentials.push_into_relation(reformatted_creds)
+    credentials.expose_credentials(reformatted_creds)
 
 
 @when_all('charm.openstack.creds.set',

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -106,6 +106,14 @@ def handle_requests():
 
 
 @when_all('charm.openstack.creds.set',
+          'credentials.connected')
+@when_not('upgrade.series.in-progress')
+def write_credentials():
+    credentials = endpoint_from_name('credentials')
+    reformatted_creds = layer.openstack.get_creds_and_reformat()
+    credentials.push_into_relation(reformatted_creds)
+
+@when_all('charm.openstack.creds.set',
           'endpoint.loadbalancer.joined')
 @when_not('upgrade.series.in-progress')
 def create_or_update_loadbalancers():


### PR DESCRIPTION
Modify openstack-integrator charm to be able to expose keystone-credentials for k8s-master

Follow up to:
https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/91

Interface change : 
https://review.opendev.org/#/c/747970/

Part of https://bugs.launchpad.net/charm-kubernetes-master/+bug/1834164