### PR TITLE
Ensure Octavia loadbalancer not modified

### DIFF
--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -291,7 +291,7 @@ def test_create_recover(impl):
     ]
     impl.list_members.return_value = ['members']
     lb.create()
-    assert lb.sg_id == 'sg_id'
+    assert lb.sg_id is None
     assert lb.fip == '4.4.4.4'
     assert lb.address == '1.1.1.1'
     assert lb.members == ['members']


### PR DESCRIPTION
The openstack-integrator is expected to be run
as a non-admin tenant/project in Openstack and
therefore should not attempt (or need) to update
security groups created by Octavia.