### PR TITLE
Prevent list being returned from data call

### DIFF
--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -723,7 +723,7 @@ class BaseLBImpl:
     def find_port(self, address):
         return _openstack('port', 'list', '--fixed-ip',
                           'ip-address={}'.format(address), '-c', 'ID', '-f',
-                          'value')
+                          'value', yaml_output=False)
 
     def get_subnet_cidr(self, name):
         return _openstack('subnet', 'show', name, '-c', 'cidr', '-f', 'value')

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -726,7 +726,8 @@ class BaseLBImpl:
                           'value', yaml_output=False)
 
     def get_subnet_cidr(self, name):
-        return _openstack('subnet', 'show', name, '-c', 'cidr', '-f', 'value')
+        return _openstack('subnet', 'show', name, '-c', 'cidr', '-f', 'value',
+                          yaml_output=False)
 
     def list_loadbalancers(self):
         raise NotImplementedError()


### PR DESCRIPTION
[LP#1899712](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1899712)

When deploying the Openstack integrator on clouds where port security is enabled the ID for the port will be returned as a list containing a dictionary of one entry (ID).

This change adds a parameter to prevent this.

