### PR TITLE
Add NRPE check for OpenStack components

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ please visit the [official Charmed Kubernetes docs](https://www.ubuntu.com/kuber
 This charm uses NRPE checks that are able to monitor servers, networks, subnets, floating-ips, security-groups and
 ports. These checks can be set through configuration using the "nrpe-<interface_type>-ids" (e.g. "nrpe-server-ids")
 option to monitor specific interfaces defined by IDs. The "nrpe-<interface_type>-ids" option could be defined as "all",
-however it is only allowed for servers networks, floating-ips and ports. Along with option "nrpe-<interface_type>-ids"
-set to value "all" it's possible to used "nrpe-skip-<interface_type>-ids" to set up interfaces, which will be skipped.
+however it is only allowed for servers, networks, floating-ips and ports. Along with option "nrpe-<interface_type>-ids"
+set to value "all", it's possible to use "nrpe-skip-<interface_type>-ids" to set up interfaces, which will be skipped.
 
-The script itself to check the OpenStack interface also supports the possibility to use the select parameter,
-which serves as a filter. (`--select name=data-port` can be used to filter out ports named "data-port")
-However this option is not configurable through the configuration.
+The NRPE script implements the select parameter for ports (--select key=value), which can help filter by the value
+of an interface property (e.g. --select name=data-port). However, this option is not configurable via Juju, hence it
+remains unsupported in the charm.
 
 
 [interface]: https://github.com/juju-solutions/interface-openstack-integration

--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@ are related to this charm.
 This charm is a component of Charmed Kubernetes. For full information,
 please visit the [official Charmed Kubernetes docs](https://www.ubuntu.com/kubernetes/docs/charm-openstack-integrator).
 
+## Nagios
+
+This charm uses NRPE checks that are able to monitor servers, networks, subnets, floating-ips, security-groups and
+ports. These checks can be set through configuration using the "nrpe-<interface_type>-ids" (e.g. "nrpe-server-ids")
+option to monitor specific interfaces defined by IDs. The "nrpe-<interface_type>-ids" option could be defined as "all",
+however it is only allowed for servers networks, floating-ips and ports. Along with option "nrpe-<interface_type>-ids"
+set to value "all" it's possible to used "nrpe-skip-<interface_type>-ids" to set up interfaces, which will be skipped.
+
+The script itself to check the OpenStack interface also supports the possibility to use the select parameter,
+which serves as a filter. (`--select name=data-port` can be used to filter out ports named "data-port")
+However this option is not configurable through the configuration.
 
 
 [interface]: https://github.com/juju-solutions/interface-openstack-integration
-

--- a/config.yaml
+++ b/config.yaml
@@ -141,7 +141,7 @@ options:
       List of OpenStack networks IDs to be checked by NRPE check. All values
       must be separated by a comma or 'all' can be entered.
     type: string
-    default: ""
+    default: "all"
   nrpe-skip-network-ids:
     description: |
       List of OpenStack networks IDs to be skipped by the NRPE check.
@@ -161,7 +161,7 @@ options:
       List of OpenStack ports IDs to be checked by NRPE check. All values
       must be separated by a comma or 'all' can be entered.
     type: string
-    default: ""
+    default: "all"
   nrpe-skip-port-ids:
     description: |
       List of OpenStack ports IDs to be skipped by the NRPE check.
@@ -175,7 +175,7 @@ options:
       List of OpenStack floating ips IDs to be checked by NRPE check. All
       values must be separated by a comma or 'all' can be entered.
     type: string
-    default: ""
+    default: "all"
   nrpe-skip-floating-ip-ids:
     description: |
       List of OpenStack floating ips IDs to be skipped by the NRPE check.
@@ -189,7 +189,7 @@ options:
       List of OpenStack servers IDs to be checked by NRPE check. All values
       must be separated by a comma or 'all' can be entered.
     type: string
-    default: ""
+    default: "all"
   nrpe-skip-server-ids:
     description: |
       List of OpenStack servers IDs to be skipped by the NRPE check.

--- a/config.yaml
+++ b/config.yaml
@@ -136,3 +136,72 @@ options:
       will use the upstream default.
     type: boolean
     default: null
+  nrpe-network-ids:
+    description: |
+      List of OpenStack networks IDs to be checked by NRPE check. All values
+      must be separated by a comma or 'all' can be entered.
+    type: string
+    default: ""
+  nrpe-skip-network-ids:
+    description: |
+      List of OpenStack networks IDs to be skipped by the NRPE check.
+      All values must be separated by a comma. The condition for using this
+      option is to set "nrpe-network-ids" to "all" or this value will raise
+      an error.
+    type: string
+    default: ""
+  nrpe-subnet-ids:
+    description: |
+      List of OpenStack subnets IDs to be checked by NRPE check. All values
+      must be separated by a comma and the value `all` is not allowed.
+    type: string
+    default: ""
+  nrpe-port-ids:
+    description: |
+      List of OpenStack ports IDs to be checked by NRPE check. All values
+      must be separated by a comma or 'all' can be entered.
+    type: string
+    default: ""
+  nrpe-skip-port-ids:
+    description: |
+      List of OpenStack ports IDs to be skipped by the NRPE check.
+      All values must be separated by a comma. The condition for using this
+      option is to set "nrpe-port-ids" to "all" or this value will raise
+      an error.
+    type: string
+    default: ""
+  nrpe-floating-ip-ids:
+    description: |
+      List of OpenStack floating ips IDs to be checked by NRPE check. All
+      values must be separated by a comma or 'all' can be entered.
+    type: string
+    default: ""
+  nrpe-skip-floating-ip-ids:
+    description: |
+      List of OpenStack floating ips IDs to be skipped by the NRPE check.
+      All values must be separated by a comma. The condition for using
+      this option is to set "nrpe-floating-ip-ids" to "all" or this value
+      will raise an error.
+    type: string
+    default: ""
+  nrpe-server-ids:
+    description: |
+      List of OpenStack servers IDs to be checked by NRPE check. All values
+      must be separated by a comma or 'all' can be entered.
+    type: string
+    default: ""
+  nrpe-skip-server-ids:
+    description: |
+      List of OpenStack servers IDs to be skipped by the NRPE check.
+      All values must be separated by a comma. The condition for using this
+      option is to set "nrpe-server-ids" to "all" or this value will raise
+      an error.
+    type: string
+    default: ""
+  nrpe-security-group-ids:
+    description: |
+      List of OpenStack security group IDs to be checked by NRPE check.
+      All values must be separated by a comma and the value `all` is not
+      allowed.
+    type: string
+    default: ""

--- a/files/nagios/plugins/check_openstack_interface.py
+++ b/files/nagios/plugins/check_openstack_interface.py
@@ -6,6 +6,7 @@
 #   Robert Gildein <robert.gildein@canonical.com>
 
 import argparse
+import os
 from configparser import ConfigParser
 
 import openstack
@@ -14,7 +15,6 @@ from nagios_plugin3 import try_check, UnknownError, CriticalError
 SEPARATOR = ","
 ACTIVE = "ACTIVE"
 DOWN = "DOWN"
-VALID_STATUS = [ACTIVE, DOWN]
 INTERFACE = {
     "network": "network.networks",
     "floating-ip": "network.ips",
@@ -43,40 +43,67 @@ def _parse_arguments():
     """
     credentials = ConfigParser()
     parser = argparse.ArgumentParser("check_openstack_interface")
-    parser.add_argument("interface", type=str, help="interface name")
+    parser.add_argument("interface", type=str, choices=INTERFACE.keys(),
+                        help="interface name")
     parser.add_argument("-c", "--credential", required=True,
-                        type=argparse.FileType("r"),
+                        type=lambda path: credentials.read_file(
+                            argparse.FileType("r")(path)),
                         help="path to OpenStack credential cnf file")
-    parser.add_argument("--all", action="store_true", help="check all")
-    parser.add_argument("-i", "--id", action="append", type=str, default=[],
-                        help="check specific id (can be used multiple times)")
+    group = parser.add_mutually_exclusive_group(required=True)
+    # section for argument -i/--id
+    group.add_argument("-i", "--id", action="append", type=str, default=[],
+                       help="check specific id (can be used multiple times)")
+
+    # section for argument --all
+    group.add_argument("--all", action="store_true", help="check all")
     parser.add_argument("--skip-id", action="append", type=str, default=[],
                         help="skip specific id (can be used multiple times)")
+
     parser.add_argument("--select", action="append", type=str, default=[],
                         help="use `--select` together with `--all` "
                              "(e.g. --select subnet=<id>) "
                              "(can be used multiple times)")
-    args = parser.parse_args()
 
-    if args.interface not in INTERFACE:
-        parser.error("`{}` interface is not supported".format(args.interface))
+    args = parser.parse_args()
 
     if args.all and args.interface in INTERFACE_BY_EXISTENCE:
         parser.error("flag `--all` is not supported with "
                      "interface {}".format(args.interface))
-    if args.all and args.id:
-        parser.error("`--all` and `--id` can't be given together")
-    elif not args.all and not args.id:
-        parser.error("at least one of '--all/--id' parameters must be entered")
     elif not args.all and args.skip_id:
         parser.error("`--skip-id` must be used with `--all`")
     elif not args.all and args.select:
         parser.error("`--select` must be used with `--all`")
 
-    credentials.read_file(args.credential)
-
     return (credentials, args.interface, set(args.id), set(args.skip_id),
             dict(arg.split("=", 1) for arg in args.select), args.all)
+
+
+def _check_output(interface, critical, notfound, unknown, healthy):
+    """Process check output."""
+    total = len(healthy.union(critical, notfound, unknown))
+    error = None
+    message = "OK: healthy {}s [{}] ({}/{})".format(
+        interface, SEPARATOR.join(healthy), len(healthy), total)
+
+    if unknown:
+        error = UnknownError
+        message = "UNKNOWN: {}s [{}] ({}/{}){}{}".format(
+            interface, SEPARATOR.join(unknown), len(unknown), total,
+            os.linesep, message)
+
+    if notfound.union(critical):
+        error = CriticalError
+        msg_notfound = "{}s not found [{}] ({}/{})".format(
+            interface, SEPARATOR.join(notfound), len(notfound), total)
+        msg_critical = "unhealthy {}s [{}] ({}/{})".format(
+            interface, SEPARATOR.join(critical), len(critical), total)
+        message = "CRITICAL: {}, {}{}{}".format(
+            msg_notfound, msg_critical, os.linesep, message)
+
+    if error:
+        raise error(message)
+
+    print(message)
 
 
 def _check_interface(name, interfaces, ids):
@@ -92,30 +119,24 @@ def _check_interface(name, interfaces, ids):
     :raise nagios_plugin3.UnknownError: if interface status is not valid
     :raise nagios_plugin3.CriticalError: if interface status is DOWN
     """
-    down, unknown, notfound = [], [], []
+    critical, notfound, unknown, healthy = set(), set(), set(), set()
 
     for id_ in ids:
         interface = interfaces.get(id_)
 
         if not interface:
-            notfound.append(id_)
+            notfound.add(id_)
         elif hasattr(interface, "status"):
-            if interface.status == DOWN:
-                down.append(id_)
-            elif interface.status not in VALID_STATUS:
-                unknown.append(id_)
+            if interface.status == ACTIVE:
+                healthy.add(id_)
+            elif interface.status == DOWN:
+                critical.add(id_)
+            else:
+                unknown.add(id_)
+        else:
+            healthy.add(id_)
 
-    if notfound:
-        raise CriticalError("{}s \"{}\" not found ({}/{})".format(
-            name, SEPARATOR.join(notfound), len(notfound), len(ids)))
-
-    if unknown:
-        raise UnknownError("{}s \"{}\" have unknown status ({}/{})".format(
-            name, SEPARATOR.join(unknown), len(unknown), len(ids)))
-
-    if down:
-        raise CriticalError("{}s \"{}\" are DOWN ({}/{})".format(
-            name, SEPARATOR.join(down), len(down), len(ids)))
+    _check_output(name, critical, notfound, unknown, healthy)
 
 
 def _interface_filter(interface, skip, select):
@@ -167,8 +188,6 @@ def check(credentials, name, ids, skip=None, select=None, check_all=False):
                if _interface_filter(i, skip, select)}
 
     _check_interface(name, interfaces, ids)
-    print("OK - All {}s passed. ({}/{}) IDs: {}".format(
-        name, len(ids), len(interfaces), SEPARATOR.join(ids)))
 
 
 def main():

--- a/files/nagios/plugins/check_openstack_interface.py
+++ b/files/nagios/plugins/check_openstack_interface.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2021 Canonical Ltd.
+
+# Authors:
+#   Robert Gildein <robert.gildein@canonical.com>
+
+import argparse
+from configparser import ConfigParser
+
+import openstack
+from nagios_plugin3 import try_check, UnknownError, CriticalError
+
+SEPARATOR = ","
+ACTIVE = "ACTIVE"
+DOWN = "DOWN"
+VALID_STATUS = [ACTIVE, DOWN]
+INTERFACE = {
+    "network": "network.networks",
+    "floating-ip": "network.ips",
+    "server": "compute.servers",
+    "port": "network.ports",
+    "security-group": "network.security_groups",
+    "subnet": "network.subnets",
+}
+INTERFACE_BY_EXISTENCE = ["security-group", "subnet"]
+
+
+def _rgetattr(obj, *attrs):
+    if len(attrs) == 0:
+        return obj
+
+    return _rgetattr(getattr(obj, attrs[0]), *attrs[1:])
+
+
+def _parse_arguments():
+    """Parse the check arguments and connect to OpenStack.
+
+    :returns: credentials, interface name, set IDs,
+              set IDs to skip, values to filter when using `--all`
+              and check all flag
+    :rtype: Tuple[configparser.ConfigParser, str, set, set, dict, bool]
+    """
+    credentials = ConfigParser()
+    parser = argparse.ArgumentParser("check_openstack_interface")
+    parser.add_argument("interface", type=str, help="interface name")
+    parser.add_argument("-c", "--credential", required=True,
+                        type=argparse.FileType("r"),
+                        help="path to OpenStack credential cnf file")
+    parser.add_argument("--all", action="store_true", help="check all")
+    parser.add_argument("-i", "--id", action="append", type=str, default=[],
+                        help="check specific id")
+    parser.add_argument("--skip-id", action="append", type=str, default=[],
+                        help="skip specific id")
+    parser.add_argument("--select", action="append", type=str, default=[],
+                        help="use `--select` together with `--all`"
+                             "(e.g. --select subnet=<id>)")
+    args = parser.parse_args()
+
+    if args.interface not in INTERFACE:
+        parser.error("`{}` interface is not supported".format(args.interface))
+
+    if args.all and args.interface in INTERFACE_BY_EXISTENCE:
+        parser.error("flag `--all` is not supported with "
+                     "interface {}".format(args.interface))
+    if args.all and args.id:
+        parser.error("`--all` and `--id` couldn't be given together")
+    elif not args.all and not args.id:
+        parser.error("at least one of '--all/--id' parameters must be entered")
+    elif not args.all and args.skip_id:
+        parser.error("`--skip-id` must be used with `--all`")
+    elif not args.all and args.select:
+        parser.error("`--select` must be used with `--all`")
+
+    credentials.read_file(args.credential)
+
+    return (credentials, args.interface, set(args.id), set(args.skip_id),
+            dict(arg.split("=", 1) for arg in args.select), args.all)
+
+
+def _check_interface(name, interfaces, ids):
+    """Check OpenStack interface existence.
+
+    :param name: OpenStack interface name
+    :type name: str
+    :param interfaces: dictionary of OpenStack interfaces
+    :type interfaces: Dict[str, Any]
+    :param ids: list of OpenStack interface IDs/names that will be checked
+    :type ids: Set[str]
+    :raise nagios_plugin3.CriticalError: if interface not found
+    :raise nagios_plugin3.UnknownError: if interface status is not valid
+    :raise nagios_plugin3.CriticalError: if interface status is DOWN
+    """
+    down, unknown, notfound = [], [], []
+
+    for id_ in ids:
+        interface = interfaces.get(id_)
+
+        if not interface:
+            notfound.append(id_)
+        elif hasattr(interface, "status"):
+            if interface.status == DOWN:
+                down.append(id_)
+            elif interface.status not in VALID_STATUS:
+                unknown.append(id_)
+
+    if notfound:
+        raise CriticalError("{}s \"{}\" not found ({}/{})".format(
+            name, SEPARATOR.join(notfound), len(notfound), len(ids)))
+
+    if unknown:
+        raise UnknownError("{}s \"{}\" have unknown status ({}/{})".format(
+            name, SEPARATOR.join(unknown), len(unknown), len(ids)))
+
+    if down:
+        raise CriticalError("{}s \"{}\" are DOWN ({}/{})".format(
+            name, SEPARATOR.join(down), len(down), len(ids)))
+
+
+def _interface_filter(interface, skip, select):
+    """Apply `--skip` and `--select` parameter to interface.
+
+    :param interface: OpenStack interface, e.g. network, port, ...
+    :type: Any
+    :param skip: OpenStack interface IDs that will be skipped [None]
+    :type skip: Set[str]
+    :param select: values for OpenStack interfaces filtering [None]
+    :type select: Dict[str, str]
+    :returns: a Boolean value to identify whether this interface is used
+    :rtype: bool
+    """
+    if interface.id in (skip or {}):
+        return False
+
+    for key, value in (select or {}).items():
+        if getattr(interface, key, None) != value:
+            return False
+
+    return True
+
+
+def check(credentials, name, ids, skip=None, select=None, check_all=False):
+    """Check OpenStack interface.
+
+    :param credentials: OpenStack credentials
+    :type credentials: configparser.ConfigParser
+    :param name: OpenStack interface name
+    :type name: str
+    :param ids: OpenStack interface IDs that will be check
+    :type ids: Set[str]
+    :param skip: OpenStack interface IDs that will be skipped [None]
+    :type skip: Set[str]
+    :param select: values for OpenStack interfaces filtering [None]
+    :type select: Dict[str, str]
+    :param check_all: flag to checking all OpenStack interfaces [False]
+    :type check_all: bool
+    :raise nagios_plugin3.CriticalError: if interface not found
+    :raise nagios_plugin3.UnknownError: if interface status is not valid
+    :raise nagios_plugin3.CriticalError: if interface status is DOWN
+    """
+    connection = openstack.connect(**credentials["openstack"])
+    interfaces = {i.id: i for i in _rgetattr(connection,
+                                             *INTERFACE[name].split("."))()}
+    if check_all:
+        ids = {i.id for i in interfaces.values()
+               if _interface_filter(i, skip, select)}
+
+    _check_interface(name, interfaces, ids)
+    print("OK - All {}s passed. ({}/{}) IDs: {}".format(
+        name, len(ids), len(interfaces), SEPARATOR.join(ids)))
+
+
+def main():
+    args = _parse_arguments()
+    try_check(check, *args)
+
+
+if __name__ == "__main__":
+    main()

--- a/files/nagios/plugins/check_openstack_interface.py
+++ b/files/nagios/plugins/check_openstack_interface.py
@@ -49,12 +49,13 @@ def _parse_arguments():
                         help="path to OpenStack credential cnf file")
     parser.add_argument("--all", action="store_true", help="check all")
     parser.add_argument("-i", "--id", action="append", type=str, default=[],
-                        help="check specific id")
+                        help="check specific id (can be used multiple times)")
     parser.add_argument("--skip-id", action="append", type=str, default=[],
-                        help="skip specific id")
+                        help="skip specific id (can be used multiple times)")
     parser.add_argument("--select", action="append", type=str, default=[],
-                        help="use `--select` together with `--all`"
-                             "(e.g. --select subnet=<id>)")
+                        help="use `--select` together with `--all` "
+                             "(e.g. --select subnet=<id>) "
+                             "(can be used multiple times)")
     args = parser.parse_args()
 
     if args.interface not in INTERFACE:
@@ -64,7 +65,7 @@ def _parse_arguments():
         parser.error("flag `--all` is not supported with "
                      "interface {}".format(args.interface))
     if args.all and args.id:
-        parser.error("`--all` and `--id` couldn't be given together")
+        parser.error("`--all` and `--id` can't be given together")
     elif not args.all and not args.id:
         parser.error("at least one of '--all/--id' parameters must be entered")
     elif not args.all and args.skip_id:

--- a/layer.yaml
+++ b/layer.yaml
@@ -3,12 +3,15 @@ includes:
   - 'layer:basic'
   - 'layer:status'
   - 'layer:snap'
+  - 'layer:nagios'
   - 'interface:openstack-integration'
   - 'interface:public-address'
   - 'interface:keystone-credentials'
 options:
   basic:
     use_venv: true
+    packages:
+      - python3-openstackclient
   snap:
     openstackclients:
       channel: stable

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -949,7 +949,6 @@ def create_nrpe_check_cmd(check):
     value_skip_ids = config.get(check.config_skip) or ""
     ids = [i for i in value_ids.split(",") if i]  # remove empty string
     skip_ids = [i for i in value_skip_ids.split(",") if i]
-    print("\n\n", config, "\n", check, "\n\n")
     script = os.path.join(
         NAGIOS_PLUGINS_DIR, nrpe_helpers.NRPE_OPENSTACK_INTERFACE)
     cmd = "{} {} -c {}".format(

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -15,14 +15,17 @@ import yaml
 
 from charmhelpers.core import hookenv
 from charmhelpers.core.unitdata import kv
+from charmhelpers.core.templating import render
 
 from charms.layer import status
+from charms.layer.nagios import NAGIOS_PLUGINS_DIR
 
 
 # When debugging hooks, for some reason HOME is set to /home/ubuntu, whereas
 # during normal hook execution, it's /root. Set it here to be consistent.
 os.environ['HOME'] = '/root'
 
+OPENSTACK_NAGIOS_CREDENTIAL_FILE = "/etc/nagios/openstack.cnf"
 CA_CERT_FILE = Path('/etc/openstack-integrator/ca.crt')
 MODEL_UUID = os.environ['JUJU_MODEL_UUID']
 MODEL_SHORT_ID = MODEL_UUID.split('-')[-1]
@@ -271,8 +274,13 @@ def _load_creds():
     return kv().get('charm.openstack.full-creds')
 
 
-def _run_with_creds(*args):
-    creds = _load_creds()
+def _get_creds_env(creds):
+    """Get environment variables from credentials.
+
+    :returns: dictionary contain all environment variables parsed from
+              credentials
+    :rtype: Dict[str, str]
+    """
     env = {
         'PATH': os.pathsep.join(['/snap/bin', os.environ['PATH']]),
         'OS_AUTH_URL': creds['auth_url'],
@@ -294,6 +302,12 @@ def _run_with_creds(*args):
     if CA_CERT_FILE.exists():
         env['OS_CACERT'] = str(CA_CERT_FILE)
 
+    return env
+
+
+def _run_with_creds(*args):
+    creds = _load_creds()
+    env = _get_creds_env(creds)
     result = subprocess.run(args,
                             env=env,
                             check=True,
@@ -902,3 +916,40 @@ class NeutronLBImpl(BaseLBImpl):
     def delete_member(self, member):
         addr, _ = member
         _neutron('lbaas-member-delete', addr, self.name)
+
+
+def write_nagios_openstack_cnf():
+    """Create a OpenStack configuration file with nagios user credentials."""
+    creds = _load_creds()
+    env = _get_creds_env(creds)
+    render("nagios-openstack.cnf", OPENSTACK_NAGIOS_CREDENTIAL_FILE, env,
+           owner="nagios", group="nagios", perms=0o640)
+    return OPENSTACK_NAGIOS_CREDENTIAL_FILE
+
+
+def remove_nagios_openstack_cnf():
+    """Remove a OpenStack configuration file with nagios user credentials."""
+    if os.path.exists(OPENSTACK_NAGIOS_CREDENTIAL_FILE):
+        os.remove(OPENSTACK_NAGIOS_CREDENTIAL_FILE)
+
+
+def create_nrpe_check_cmd(
+        script, interface, ids, skip_ids, check_all):
+    """Crete cmd command for checking OpenStack IDs/names."""
+    ids = [i for i in (ids or "").split(",") if i]  # remove empty string
+    skip_ids = [i for i in (skip_ids or "").split(",") if i]
+    cmd = "{} {} -c {}".format(os.path.join(NAGIOS_PLUGINS_DIR, script),
+                               interface, OPENSTACK_NAGIOS_CREDENTIAL_FILE)
+
+    if "all" in ids:
+        if not check_all:
+            raise ValueError("value 'all' is not supported")
+        cmd += " --all"
+        cmd += "".join([" --skip-id {}".format(i) for i in skip_ids])
+    elif skip_ids:
+        raise ValueError("skip-ids option is not allowed with ids option "
+                         "not set to `all`")
+    else:
+        cmd += "".join([" --id {}".format(i) for i in ids])
+
+    return cmd

--- a/lib/nrpe_helpers.py
+++ b/lib/nrpe_helpers.py
@@ -1,0 +1,34 @@
+import collections
+
+# NOTE (rgildein): This namedtuple is used to define NRPE check. Composed of:
+#                  name - NRPE check shortname
+#                  interface - OpenStack interface to be check
+#                  config - option name defined in config.yaml
+#                  config_skip - option name define in config.yaml
+#                  all - if the option in config.yaml can be `all`
+NrpeCheck = collections.namedtuple(
+    "NRPE_CHECK", "name interface config config_skip all")
+
+NRPE_CHECKS = [
+    # check , OpenStack interface, check_all allowed, skip ids
+    NrpeCheck("kubernetes_subnet", "subnet", "subnet-id", None, False),
+    NrpeCheck("kubernetes_network", "network", "floating-network-id",
+              None, False),
+    NrpeCheck("openstack_networks", "network", "nrpe-network-ids",
+              "nrpe-skip-network-ids", True),
+    NrpeCheck("openstack_subnets", "subnet", "nrpe-subnet-ids", None, False),
+    NrpeCheck("openstack_ports", "port", "nrpe-port-ids", "nrpe-skip-port-ids",
+              True),
+    NrpeCheck("openstack_floating_ips", "floating-ip", "nrpe-floating-ip-ids",
+              "nrpe-skip-floating-ip-ids", True),
+    NrpeCheck("openstack_servers", "server", "nrpe-server-ids",
+              "nrpe-skip-server-ids", True),
+    NrpeCheck("openstack_security_groups", "security-group",
+              "nrpe-security-group-ids", None, False),
+]
+NRPE_OPENSTACK_INTERFACE = "check_openstack_interface.py"
+NRPE_CONFIG_FLAGS_CHANGED = [
+    *["config.changed.{}".format(c.config) for c in NRPE_CHECKS],
+    *["config.changed.{}".format(c.config_skip) for c in NRPE_CHECKS
+      if c.config_skip]
+]

--- a/lib/nrpe_helpers.py
+++ b/lib/nrpe_helpers.py
@@ -1,4 +1,11 @@
 import collections
+import os
+
+from charmhelpers.core import hookenv
+from charmhelpers.core.templating import render
+from charms.layer.nagios import NAGIOS_PLUGINS_DIR
+from charms.layer.openstack import get_creds_env, get_user_credentials
+
 
 # NOTE (rgildein): This namedtuple is used to define NRPE check. Composed of:
 #                  name - NRPE check shortname
@@ -32,3 +39,54 @@ NRPE_CONFIG_FLAGS_CHANGED = [
     *["config.changed.{}".format(c.config_skip) for c in NRPE_CHECKS
       if c.config_skip]
 ]
+OPENSTACK_NAGIOS_CREDENTIAL_FILE = "/etc/nagios/openstack.cnf"
+
+
+def write_nagios_openstack_cnf():
+    """Create a OpenStack configuration file with nagios user credentials."""
+    creds = get_user_credentials()
+    env = get_creds_env(creds)
+    render("nagios-openstack.cnf", OPENSTACK_NAGIOS_CREDENTIAL_FILE, env,
+           owner="nagios", group="nagios", perms=0o640)
+    return OPENSTACK_NAGIOS_CREDENTIAL_FILE
+
+
+def remove_nagios_openstack_cnf():
+    """Remove a OpenStack configuration file with nagios user credentials."""
+    if os.path.exists(OPENSTACK_NAGIOS_CREDENTIAL_FILE):
+        os.remove(OPENSTACK_NAGIOS_CREDENTIAL_FILE)
+
+
+def create_nrpe_check_cmd(check):
+    """Crete cmd command for checking OpenStack IDs.
+
+    :param check: Definition NRPE check for OpenStack interface
+    :type check: nrpe_helpers.NrpeCheck
+    :returns: NRPE check CMD
+    :rtype: string
+    :raise ValueError: if the IDs is set to "all" and is not supported
+                       if skip IDs are set, but without IDs set to "all"
+    """
+    config = hookenv.config()
+    value_ids = config.get(check.config) or ""
+    value_skip_ids = config.get(check.config_skip) or ""
+    ids = [i for i in value_ids.split(",") if i]  # remove empty string
+    skip_ids = [i for i in value_skip_ids.split(",") if i]
+    script = os.path.join(NAGIOS_PLUGINS_DIR, NRPE_OPENSTACK_INTERFACE)
+    cmd = "{} {} -c {}".format(
+        script, check.interface, OPENSTACK_NAGIOS_CREDENTIAL_FILE)
+
+    if "all" in ids:
+        if not check.all:
+            raise ValueError("value \"all\" is not supported with "
+                             "\"{}\"".format(check.config))
+        cmd += " --all"
+        cmd += "".join([" --skip-id {}".format(i) for i in skip_ids])
+    elif skip_ids:
+        raise ValueError("\"{}\" option is not allowed with \"{}\" option "
+                         "not set to \"all\"".format(check.config_skip,
+                                                     check.config))
+    else:
+        cmd += "".join([" --id {}".format(i) for i in ids])
+
+    return cmd

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -176,7 +176,7 @@ def update_nrpe_config():
                 check_cmd=cmd)
             hookenv.log("NRPE check {} was added".format(check.name),
                         level=hookenv.DEBUG)
-        elif not config.get(check.config):
+        elif config.changed(check.config) and not config.get(check.config):
             nrpe_setup.remove_check(shortname=check.name, description="",
                                     check_cmd=cmd)
             hookenv.log("NRPE check {} was removed".format(check.name),

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -161,13 +161,13 @@ def update_nrpe_config(initialized=False):
     config = hookenv.config()
     hostname = nrpe.get_nagios_hostname()
     nrpe_setup = nrpe.NRPE(hostname=hostname)
-    layer.openstack.write_nagios_openstack_cnf()
+    nrpe_helpers.write_nagios_openstack_cnf()
     layer.nagios.install_nagios_plugin_from_file(
         "files/nagios/plugins/check_openstack_interface.py",
         nrpe_helpers.NRPE_OPENSTACK_INTERFACE)
 
     for check in nrpe_helpers.NRPE_CHECKS:
-        cmd = layer.openstack.create_nrpe_check_cmd(check)
+        cmd = nrpe_helpers.create_nrpe_check_cmd(check)
         if (config.get(check.config) and (config.changed(check.config) or
                                           config.changed(check.config_skip) or
                                           initialized)):
@@ -197,7 +197,7 @@ def remove_nrpe_config():
     nrpe_setup = nrpe.NRPE(hostname=hostname)
 
     for check in nrpe_helpers.NRPE_CHECKS:
-        cmd = layer.openstack.create_nrpe_check_cmd(check)
+        cmd = nrpe_helpers.create_nrpe_check_cmd(check)
 
         if config.get(check.config):
             nrpe_setup.remove_check(
@@ -210,6 +210,6 @@ def remove_nrpe_config():
 
     nrpe_setup.write()
     layer.nagios.remove_nagios_plugin(nrpe_helpers.NRPE_OPENSTACK_INTERFACE)
-    layer.openstack.remove_nagios_openstack_cnf()
+    nrpe_helpers.remove_nagios_openstack_cnf()
     clear_flag("nrpe-external-master.initial-config")
     hookenv.log("NRPE checks was removed.", level=hookenv.DEBUG)

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -166,10 +166,7 @@ def update_nrpe_config():
         nrpe_helpers.NRPE_OPENSTACK_INTERFACE)
 
     for check in nrpe_helpers.NRPE_CHECKS:
-        cmd = layer.openstack.create_nrpe_check_cmd(
-            nrpe_helpers.NRPE_OPENSTACK_INTERFACE, check.interface,
-            config.get(check.config), config.get(check.config_skip), check.all)
-
+        cmd = layer.openstack.create_nrpe_check_cmd(check)
         if ((config.changed(check.config) or config.changed(check.config_skip))
                 and config.get(check.config)):
             nrpe_setup.add_check(
@@ -198,9 +195,7 @@ def remove_nrpe_config():
     nrpe_setup = nrpe.NRPE(hostname=hostname)
 
     for check in nrpe_helpers.NRPE_CHECKS:
-        cmd = layer.openstack.create_nrpe_check_cmd(
-            nrpe_helpers.NRPE_OPENSTACK_INTERFACE, check.interface,
-            config.get(check.config), config.get(check.config_skip), check.all)
+        cmd = layer.openstack.create_nrpe_check_cmd(check)
 
         if config.get(check.config):
             nrpe_setup.remove_check(

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -203,7 +203,7 @@ def remove_nrpe_config():
             nrpe_setup.remove_check(
                 shortname=check.name,
                 description="",
-                chech_cmd=cmd
+                check_cmd=cmd
             )
             hookenv.log("NRPE check {} was removed".format(check.name),
                         level=hookenv.DEBUG)

--- a/templates/nagios-openstack.cnf
+++ b/templates/nagios-openstack.cnf
@@ -1,0 +1,10 @@
+[openstack]
+auth_url={{ OS_AUTH_URL }}
+username={{ OS_USERNAME }}
+password={{ OS_PASSWORD }}
+region_name={{ OS_REGION_NAME }}
+user_domain_name={{ OS_USER_DOMAIN_NAME }}
+project_name={{ OS_PROJECT_NAME }}
+project_domain_name={{ OS_PROJECT_DOMAIN_NAME }}
+identity_api_version={{ OS_IDENTITY_API_VERSION }}
+cacert={{ OS_CACERT }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,4 @@
-from unittest import mock
-from unittest.mock import patch, MagicMock
-
-import pytest
+from unittest.mock import patch
 
 import charms.unit_test
 
@@ -13,16 +10,6 @@ charms.unit_test.patch_module('subprocess')
 charms.unit_test.patch_module('urllib.request')
 charms.unit_test.patch_module('charms.leadership')
 patch('time.sleep').start()
-
-
-@pytest.fixture
-def config():
-    with mock.patch("charmhelpers.core.hookenv.config") as mock_config:
-        mock_config.return_value = _config = MagicMock()
-        _config.get.return_value = None
-        _config.changed.return_value = True
-
-        yield _config
 
 
 log_err = patch_fixture('charms.layer.openstack.log_err')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 
 import charms.unit_test
 
+from charms.unit_test import patch_fixture
+
 
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module('subprocess')
@@ -21,3 +23,24 @@ def config():
         _config.changed.return_value = True
 
         yield _config
+
+
+log_err = patch_fixture('charms.layer.openstack.log_err')
+_load_creds = patch_fixture('charms.layer.openstack._load_creds')
+detect_octavia = patch_fixture('charms.layer.openstack.detect_octavia')
+_run_with_creds = patch_fixture('charms.layer.openstack._run_with_creds')
+_openstack = patch_fixture('charms.layer.openstack._openstack')
+_neutron = patch_fixture('charms.layer.openstack._neutron')
+LoadBalancerClient = patch_fixture('charms.layer.openstack.LoadBalancerClient')
+OctaviaLBClient = patch_fixture('charms.layer.openstack.OctaviaLBClient')
+NeutronLBClient = patch_fixture('charms.layer.openstack.NeutronLBClient')
+_default_subnet = patch_fixture('charms.layer.openstack._default_subnet')
+kv = patch_fixture('charms.layer.openstack.kv')
+openstack_config = patch_fixture('charms.layer.openstack.config')
+get_port_sec_enabled = patch_fixture('charms.layer.openstack.BaseLBImpl'
+                                     '.get_port_sec_enabled',
+                                     patch_opts={'return_value': True},
+                                     fixture_opts={'autouse': True})
+_normalize_creds = patch_fixture('charms.layer.openstack._normalize_creds')
+_save_creds = patch_fixture('charms.layer.openstack._save_creds')
+_determine_version = patch_fixture('charms.layer.openstack._determine_version')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ OctaviaLBClient = patch_fixture('charms.layer.openstack.OctaviaLBClient')
 NeutronLBClient = patch_fixture('charms.layer.openstack.NeutronLBClient')
 _default_subnet = patch_fixture('charms.layer.openstack._default_subnet')
 kv = patch_fixture('charms.layer.openstack.kv')
-openstack_config = patch_fixture('charms.layer.openstack.config')
+config = patch_fixture('charms.layer.openstack.config')
 get_port_sec_enabled = patch_fixture('charms.layer.openstack.BaseLBImpl'
                                      '.get_port_sec_enabled',
                                      patch_opts={'return_value': True},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
-from unittest.mock import patch
+from unittest import mock
+from unittest.mock import patch, MagicMock
+
+import pytest
 
 import charms.unit_test
 
@@ -6,4 +9,15 @@ import charms.unit_test
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module('subprocess')
 charms.unit_test.patch_module('urllib.request')
+charms.unit_test.patch_module('charms.leadership')
 patch('time.sleep').start()
+
+
+@pytest.fixture
+def config():
+    with mock.patch("charmhelpers.core.hookenv.config") as mock_config:
+        mock_config.return_value = _config = MagicMock()
+        _config.get.return_value = None
+        _config.changed.return_value = True
+
+        yield _config

--- a/tests/nagios/plugins/conftest.py
+++ b/tests/nagios/plugins/conftest.py
@@ -35,7 +35,7 @@ def get_id(name):
 
 @pytest.fixture
 def credentials():
-    yield {"openstack": {}}
+    yield {"openstack": {"auth_url": "127.0.0.1"}}
 
 
 @pytest.fixture
@@ -60,7 +60,7 @@ def mock_openstack(monkeypatch):
     fake_connection.network.ports.side_effect = lambda: [
         port for port in INTERFACES.values() if port.type == "port"]
 
-    monkeypatch.setattr(openstack, "connect", lambda: fake_connection)
+    monkeypatch.setattr(openstack, "connect", lambda auth_url: fake_connection)
 
     yield fake_connection
 

--- a/tests/nagios/plugins/conftest.py
+++ b/tests/nagios/plugins/conftest.py
@@ -1,0 +1,88 @@
+from configparser import ConfigParser
+from unittest.mock import MagicMock
+
+import openstack
+import pytest
+
+INTERFACES = {}
+
+
+class FakeOpenStackInterface:
+    def __init__(self, interface_type, interface_id, status=None, **kwargs):
+        self._interface_type = interface_type
+        self._id = interface_id
+        if status is not None:
+            self.status = status
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def name(self):
+        return "{}-{}".format(self._interface_type, self._id)
+
+    @property
+    def type(self):
+        return self._interface_type
+
+
+def get_id(name):
+    return name.split("-")[-1]
+
+
+@pytest.fixture
+def credentials():
+    yield {"openstack": {}}
+
+
+@pytest.fixture
+def credentials_cnf(tmpdir, credentials):
+    config = ConfigParser()
+    config.read_dict(credentials)
+    path = tmpdir.join("test.cnf")
+    with open(path, "w") as file:
+        config.write(file)
+
+    yield path.strpath
+
+
+@pytest.fixture(autouse=True)
+def mock_openstack(monkeypatch):
+    global INTERFACES
+    fake_connection = MagicMock()
+    fake_connection.network.networks.side_effect = lambda: [
+        net for net in INTERFACES.values() if net.type == "network"]
+    fake_connection.network.subnets.side_effect = lambda: [
+        subnet for subnet in INTERFACES.values() if subnet.type == "subnet"]
+    fake_connection.network.ports.side_effect = lambda: [
+        port for port in INTERFACES.values() if port.type == "port"]
+
+    monkeypatch.setattr(openstack, "connect", lambda: fake_connection)
+
+    yield fake_connection
+
+    INTERFACES.clear()
+
+
+@pytest.fixture
+def add_interface():
+    def _add_interface(interface, interface_id, **kwargs):
+        global INTERFACES
+        INTERFACES.update({
+            interface_id: FakeOpenStackInterface(interface, interface_id,
+                                                 **kwargs)
+        })
+
+    yield _add_interface
+
+
+@pytest.fixture
+def remove_interface():
+    def _remove_interface(interface_id):
+        global INTERFACES
+        del INTERFACES[interface_id]
+
+    yield _remove_interface

--- a/tests/nagios/plugins/download_nagios_plugin3.py
+++ b/tests/nagios/plugins/download_nagios_plugin3.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import os.path
+import sys
+import urllib.request
+from glob import glob
+
+MODULE_NAME = "nagios_plugin3.py"
+MODULE_URL = os.path.join("https://git.launchpad.net/nrpe-charm/plain/files",
+                          MODULE_NAME)
+_cache = None
+
+
+def content():
+    global _cache
+    if _cache is None:
+        _cache = urllib.request.urlopen(MODULE_URL).read()
+    assert len(_cache) > 0
+    return _cache
+
+
+def main(env_path):
+    for i in glob(os.path.join(env_path, "lib/python3*", "site-packages")):
+        mod_path = os.path.join(i, MODULE_NAME)
+        if os.path.isdir(i) and not os.path.exists(mod_path):
+            open(mod_path, "wb").write(content())
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/tests/nagios/plugins/test_check_openstack_interface.py
+++ b/tests/nagios/plugins/test_check_openstack_interface.py
@@ -1,0 +1,135 @@
+import sys
+from unittest import mock
+
+import pytest
+
+from nagios_plugin3 import CriticalError, UnknownError
+
+sys.path.append("files/nagios/plugins")
+
+from check_openstack_interface import check, _parse_arguments  # noqa: E402
+
+
+def check_raises(exp_error, exp_count, *args, **kwargs):
+
+    def sep_join(interfaces):
+        assert exp_count == len(interfaces), "Unexpected number of interfaces"
+        return ",".join(interfaces)
+
+    with mock.patch("check_openstack_interface.SEPARATOR") as mock_sep:
+        mock_sep.join.side_effect = sep_join
+        if exp_error:
+            with pytest.raises(exp_error):
+                check(*args, **kwargs)
+        else:
+            check(*args, **kwargs)
+
+
+@pytest.mark.parametrize("networks,ids,kwargs,exp_error,exp_count", [
+    ([("1", "ACTIVE")], set(), {"check_all": True}, None, 1),
+    ([("1", "ACTIVE"), ("2", "DOWN")], set(),
+     {"skip": {"2"}, "check_all": True}, None, 1),
+    ([("1", "ACTIVE"), ("2", "DOWN")], set(), {"check_all": True},
+     CriticalError, 1),
+    ([("1", "ACTIVE"), ("2", "TEST")], set(),
+     {"check_all": True}, UnknownError, 1),
+    ([("1", "ACTIVE"), ("2", "TEST")], {"1"}, {}, None, 1),
+    ([("1", "ACTIVE"), ("2", "TEST")], set(),
+     {"skip": {"2"}, "check_all": True}, None, 1),
+    ([("1", "ACTIVE"), ("2", "DOWN")], {"1"}, {}, None, 1),
+    ([("1", "ACTIVE"), ("2", "DOWN")], {"1", "2"}, {}, CriticalError, 1),
+    ([("1", "DOWN"), ("2", "DOWN")], {"1", "2"}, {}, CriticalError, 2),
+    ([("1", "ACTIVE"), ("2", "DOWN")], {"3"}, {}, CriticalError, 1)
+])
+def test_check_openstack_interface_network(
+        networks, ids, kwargs, exp_error, exp_count, credentials,
+        add_interface):
+    """Test NRPE check for OpenStack networks."""
+    for net_id, status in networks:
+        add_interface("network", interface_id=net_id, status=status)
+
+    check_raises(exp_error, exp_count, credentials, "network", ids, **kwargs)
+
+
+@pytest.mark.parametrize("subnets,ids,exp_error,exp_count", [
+    (["1"], {"1"}, None, 1),
+    (["1", "2"], {"2"}, None, 1),
+    (["1", "2", "3"], {"4"}, CriticalError, 1),
+    (["1", "2", "3"], {"1", "2", "3"}, None, 3)
+])
+def test_check_openstack_interface_subnet(
+        subnets, ids, exp_error, exp_count, credentials, add_interface):
+    """Test NRPE check for OpenStack subnets (without 'status')."""
+    for subnet_id in subnets:
+        add_interface("subnet", interface_id=subnet_id)
+
+    check_raises(exp_error, exp_count, credentials, "subnet", ids)
+
+
+@pytest.mark.parametrize("ports,skip,select,exp_error,exp_count", [
+    ([("1", {"status": "ACTIVE"})], {}, {}, None, 1),
+    ([("1", {"status": "ACTIVE"}), ("2", {"status": "DOWN"})], {"2"}, {},
+     None, 1),
+    ([("1", {"status": "ACTIVE", "network_id": "ext"}),
+      ("2", {"status": "DOWN", "network_id": "int"})], {},
+     {"network_id": "int"}, CriticalError, 1),
+    ([("1", {"status": "ACTIVE", "network_id": "ext"}),
+      ("2", {"status": "DOWN", "network_id": "int"})], {},
+     {"network_id": "ext"}, None, 1),
+    ([("1", {"status": "DOWN"})], {}, {"tenant_id": "test"}, None, 0),
+    ([("1", {"status": "DOWN", "tenant_id": "test"})], {},
+     {"tenant_id": "test"}, CriticalError, 1),
+    ([("1", {"status": "DOWN", "tenant_id": "test", "network_id": "ext"})], {},
+     {"tenant_id": "test", "network_id": "int"}, None, 0),
+    ([("1", {"status": "DOWN", "tenant_id": "test", "network_id": "ext"})], {},
+     {"tenant_id": "test", "network_id": "ext"}, CriticalError, 1),
+    ([("1", {"status": "DOWN", "tenant_id": "test", "network_id": "ext"})], {},
+     {"tenant_id": "test", "network_id": "ext"}, CriticalError, 1),
+    ([(str(i), {"status": "ACTIVE", "network_id": "ext"}) for i in range(10)],
+     {}, {"network_id": "ext"}, None, 10),
+])
+def test_check_openstack_interface_port(
+        ports, skip, select, exp_error, exp_count, credentials, add_interface):
+    """Test NRPE check for OpenStack ports (apply skip-id and select)."""
+    for port_id, kwargs in ports:
+        add_interface("port", interface_id=port_id, **kwargs)
+
+    check_raises(exp_error, exp_count, credentials, "port", {},
+                 skip=skip, select=select, check_all=True)
+
+
+@pytest.mark.parametrize("args,exp_output", [
+    (["--all"], (set(), set(), dict(), True)),
+    (["--id", "1", "--id", "2"], ({"1", "2"}, set(), dict(), False)),
+    (["-i", "1", "-i", "2"], ({"1", "2"}, set(), dict(), False)),
+    (["--all", "--skip-id", "2"], (set(), {"2"}, dict(), True)),
+    (["--all", "--skip-id", "2", "--skip-id", "3"],
+     (set(), {"2", "3"}, dict(), True)),
+    (["--all", "--skip-id", "2", "--select", "a=b"],
+     (set(), {"2"}, {"a": "b"}, True))
+])
+def test_parse_arguments(args, exp_output, monkeypatch, credentials_cnf):
+    """Test configuration of argparse.parser"""
+    monkeypatch.setattr(sys, "argv",
+                        ["", "network", "-c", credentials_cnf, *args])
+    output = _parse_arguments()
+
+    assert exp_output == output[2:]
+
+
+@pytest.mark.parametrize("interface,args", [
+    ("network", ["-i", "1", "--all"]),
+    ("network", ["-i", "1", "--skip-id", "1"]),
+    ("network", ["-i", "1", "--select", "a=b"]),
+    ("wrong-interface", ["-i", "1"]),
+    ("security-group", ["--all"]),
+    ("subnet", ["--all"]),
+    ("network", ["--skip-id", "1"])
+])
+def test_parse_arguments_error(interface, args, monkeypatch, credentials_cnf):
+    """Test configuration of argparse.parser raise error"""
+    monkeypatch.setattr(sys, "argv",
+                        ["", interface, "-c", credentials_cnf, *args])
+
+    with pytest.raises(SystemExit):
+        _parse_arguments()

--- a/tests/test_nrpe_helpers.py
+++ b/tests/test_nrpe_helpers.py
@@ -1,0 +1,39 @@
+import pytest
+
+import nrpe_helpers
+
+from charmhelpers.core.hookenv import config
+
+
+@pytest.mark.parametrize("ids,skip_ids,check_all,exp_cmd", [
+    ("1,2", "", False, "--id 1 --id 2"),
+    ("all", "1,2", True, "--all --skip-id 1 --skip-id 2"),
+    ("all", "1,2", True, "--all --skip-id 1 --skip-id 2"),
+])
+def test_create_nrpe_check_cmd(ids, skip_ids, check_all, exp_cmd):
+    """Test creating cmd for NRPE check."""
+    config.return_value = {
+        "nrpe_check_cmd-ids": ids, "nrpe_check_cmd-skip-ids": skip_ids,
+    }
+    check = nrpe_helpers.NrpeCheck("test", "test", "nrpe_check_cmd-ids",
+                                   "nrpe_check_cmd-skip-ids", check_all)
+
+    cmd = nrpe_helpers.create_nrpe_check_cmd(check)
+
+    assert exp_cmd in cmd
+
+
+@pytest.mark.parametrize("ids,skip_ids,check_all", [
+    ("all", "", False),
+    ("1,2", "1", True),
+])
+def test_create_nrpe_check_cmd_error(ids, skip_ids, check_all):
+    """Test creating cmd for NRPE check."""
+    config.return_value = {
+        "nrpe_check_cmd-ids": ids, "nrpe_check_cmd-skip-ids": skip_ids,
+    }
+    check = nrpe_helpers.NrpeCheck("test", "test", "nrpe_check_cmd-ids",
+                                   "nrpe_check_cmd-skip-ids", check_all)
+
+    with pytest.raises(ValueError):
+        nrpe_helpers.create_nrpe_check_cmd(check)

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -1,10 +1,13 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
-import nrpe_helpers
+import pytest
 
 from reactive import openstack
+from charms.layer.nagios import NAGIOS_PLUGINS_DIR
 from charms.reactive import is_flag_set
+from charmhelpers.contrib.charmsupport import nrpe
+from charmhelpers.core.hookenv import config
 
 
 @mock.patch("reactive.openstack.update_nrpe_config")
@@ -14,82 +17,104 @@ def test_initial_nrpe_config(mock_update_nrpe_config):
     mock_update_nrpe_config.assert_called_once()
 
 
-@mock.patch("charms.layer.openstack._get_creds_env")
-@mock.patch("charms.layer.openstack.create_nrpe_check_cmd")
-@mock.patch("charmhelpers.contrib.charmsupport.nrpe.NRPE")
-def test_update_nrpe_config(mock_nrpe, mock_create_nrpe_check_cmd,
-                            mock_get_creds_env, config):
-    mock_create_nrpe_check_cmd.return_value = "test cmd"
-    mock_nrpe_setup = MagicMock()
-    mock_nrpe.return_value = mock_nrpe_setup
-    mock_get_creds_env.return_value = {}
+@mock.patch("charms.layer.openstack.write_nagios_openstack_cnf")
+def test_update_nrpe_config(mock_write_nagios_openstack_cnf, openstack_config):
+    nrpe.NRPE.return_value = mock_nrpe_setup = MagicMock()
+    NAGIOS_PLUGINS_DIR.__fspath__.return_value = "/test/"
+    config.return_value = openstack_config
 
-    # no NRPE checks were added
+    # no NRPE checks were added / deleted
+    openstack_config.changed.return_value = False
+    openstack_config.get.side_effect = {}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_not_called()
-    assert mock_nrpe_setup.remove_check.call_count == 8
+    mock_nrpe_setup.remove_check.assert_not_called()
+    mock_write_nagios_openstack_cnf.assert_called_once_with()
+    mock_write_nagios_openstack_cnf.reset_mock()
     mock_nrpe_setup.reset_mock()
+    openstack_config.reset_mock()
 
     # add NRPE check for kubernetes subnet
-    config.get.side_effect = lambda k: {"subnet-id": "1234"}.get(k)
+    openstack_config.changed.return_value = True
+    openstack_config.get.side_effect = {"subnet-id": "1234"}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_called_once_with(
         shortname="kubernetes_subnet",
         description="Check subnets: 1234",
-        check_cmd="test cmd"
+        check_cmd="/test/check_openstack_interface.py subnet "
+                  "-c /etc/nagios/openstack.cnf --id 1234"
     )
     assert mock_nrpe_setup.remove_check.call_count == 7
-    mock_create_nrpe_check_cmd.assert_any_call(nrpe_helpers.NRPE_CHECKS[0])
     mock_nrpe_setup.reset_mock()
-    mock_create_nrpe_check_cmd.reset_mock()
+    openstack_config.reset_mock()
 
     # add NRPE check for servers
-    config.get.side_effect = lambda k: {"nrpe-server-ids": "1,2,3"}.get(k)
+    openstack_config.changed.return_value = True
+    openstack_config.get.side_effect = {"nrpe-server-ids": "1,2,3"}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_called_once_with(
         shortname="openstack_servers",
         description="Check servers: 1,2,3",
-        check_cmd="test cmd"
+        check_cmd="/test/check_openstack_interface.py server "
+                  "-c /etc/nagios/openstack.cnf --id 1 --id 2 --id 3"
     )
-    mock_create_nrpe_check_cmd.assert_any_call(nrpe_helpers.NRPE_CHECKS[6])
     assert mock_nrpe_setup.remove_check.call_count == 7
     mock_nrpe_setup.reset_mock()
-    mock_create_nrpe_check_cmd.reset_mock()
+    openstack_config.reset_mock()
 
-    # add NRPE check for networks with skip-ids
-    test_config = {"nrpe-server-ids": "all", "nrpe-skip-server-ids": "1,2"}
-    config.get.side_effect = lambda k: test_config.get(k)
+    # add NRPE check for servers with skip-ids
+    openstack_config.changed.return_value = True
+    openstack_config.get.side_effect = {"nrpe-server-ids": "all",
+                                        "nrpe-skip-server-ids": "1,2"}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_called_once_with(
         shortname="openstack_servers",
         description="Check servers: all",
-        check_cmd="test cmd"
+        check_cmd="/test/check_openstack_interface.py server "
+                  "-c /etc/nagios/openstack.cnf --all --skip-id 1 --skip-id 2"
     )
-    mock_create_nrpe_check_cmd.assert_any_call(nrpe_helpers.NRPE_CHECKS[6])
     assert mock_nrpe_setup.remove_check.call_count == 7
     mock_nrpe_setup.reset_mock()
-    mock_create_nrpe_check_cmd.reset_mock()
+    openstack_config.reset_mock()
+
+    # raise a ValueError while adding NRPE check
+    openstack_config.changed.return_value = True
+    openstack_config.get.side_effect = {"nrpe-server-ids": "1,2",
+                                        "nrpe-skip-server-ids": "1"}.get
+    with pytest.raises(ValueError):
+        openstack.update_nrpe_config()
+
+    openstack_config.get.side_effect = {"subnet-id": "all"}.get
+
+    with pytest.raises(ValueError):
+        openstack.update_nrpe_config()
+
+    openstack_config.reset_mock()
 
 
-@mock.patch("charms.layer.openstack._get_creds_env")
-@mock.patch("charms.layer.openstack.create_nrpe_check_cmd")
-@mock.patch("charmhelpers.contrib.charmsupport.nrpe.NRPE")
-def test_remove_nrpe_config(mock_nrpe, mock_create_nrpe_check_cmd,
-                            mock_get_creds_env, config):
-    mock_create_nrpe_check_cmd.return_value = "test cmd"
-    mock_nrpe_setup = MagicMock()
-    mock_nrpe.return_value = mock_nrpe_setup
-    mock_get_creds_env.return_value = {}
+@mock.patch("charms.layer.openstack.remove_nagios_openstack_cnf")
+def test_remove_nrpe_config(mock_remove_nagios_openstack_cnf,
+                            openstack_config):
+    nrpe.NRPE.return_value = mock_nrpe_setup = MagicMock()
+    NAGIOS_PLUGINS_DIR.__fspath__.return_value = "/test/"
+    config.return_value = openstack_config
 
     # no NRPE checks were removed
+    openstack_config.get.side_effect = {}.get
     openstack.remove_nrpe_config()
     mock_nrpe_setup.remove_check.assert_not_called()
+    mock_remove_nagios_openstack_cnf.assert_called_once_with()
+    mock_remove_nagios_openstack_cnf.reset_mock()
     mock_nrpe_setup.reset_mock()
 
     # remove NRPE check for kubernetes network
-    config.get.side_effect = lambda k: {"floating-network-id": "1"}.get(k)
+    openstack_config.get.side_effect = {"nrpe-server-ids": "1,2,3"}.get
     openstack.remove_nrpe_config()
-    mock_nrpe_setup.remove_check.assert_called_with(
-        shortname="kubernetes_network", description="", chech_cmd="test cmd"
+    mock_nrpe_setup.remove_check.assert_called_once_with(
+        shortname="openstack_servers", description="",
+        chech_cmd="/test/check_openstack_interface.py server "
+                  "-c /etc/nagios/openstack.cnf --id 1 --id 2 --id 3"
     )
+    mock_remove_nagios_openstack_cnf.assert_called_once_with()
+    mock_remove_nagios_openstack_cnf.reset_mock()
     mock_nrpe_setup.reset_mock()

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -5,15 +5,29 @@ import pytest
 
 from reactive import openstack
 from charms.layer.nagios import NAGIOS_PLUGINS_DIR
-from charms.reactive import is_flag_set
+from charms.reactive import clear_flag, is_flag_set
 from charmhelpers.contrib.charmsupport import nrpe
 from charmhelpers.core.hookenv import config
 
 
 @mock.patch("reactive.openstack.update_nrpe_config")
 def test_initial_nrpe_config(mock_update_nrpe_config):
+    clear_flag("nrpe-external-master.initial-config")
     openstack.initial_nrpe_config()
     assert is_flag_set("nrpe-external-master.initial-config")
+    mock_update_nrpe_config.assert_called_once()
+
+
+@mock.patch("reactive.openstack.update_nrpe_config")
+def test_initial_nrpe_config_failed(mock_update_nrpe_config):
+    def raise_error():
+        raise Exception("test error")
+    mock_update_nrpe_config.side_effect = raise_error
+    clear_flag("nrpe-external-master.initial-config")
+
+    with pytest.raises(Exception):
+        openstack.initial_nrpe_config()
+    assert not is_flag_set("nrpe-external-master.initial-config")
     mock_update_nrpe_config.assert_called_once()
 
 

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -39,8 +39,7 @@ def test_update_nrpe_config(mock_nrpe, mock_create_nrpe_check_cmd,
         check_cmd="test cmd"
     )
     assert mock_nrpe_setup.remove_check.call_count == 7
-    mock_create_nrpe_check_cmd.assert_any_call(
-        nrpe_helpers.NRPE_OPENSTACK_INTERFACE, "subnet", "1234", None, False)
+    mock_create_nrpe_check_cmd.assert_any_call(nrpe_helpers.NRPE_CHECKS[0])
     mock_nrpe_setup.reset_mock()
     mock_create_nrpe_check_cmd.reset_mock()
 
@@ -52,8 +51,7 @@ def test_update_nrpe_config(mock_nrpe, mock_create_nrpe_check_cmd,
         description="Check servers: 1,2,3",
         check_cmd="test cmd"
     )
-    mock_create_nrpe_check_cmd.assert_any_call(
-        nrpe_helpers.NRPE_OPENSTACK_INTERFACE, "server", "1,2,3", None, True)
+    mock_create_nrpe_check_cmd.assert_any_call(nrpe_helpers.NRPE_CHECKS[6])
     assert mock_nrpe_setup.remove_check.call_count == 7
     mock_nrpe_setup.reset_mock()
     mock_create_nrpe_check_cmd.reset_mock()
@@ -67,8 +65,7 @@ def test_update_nrpe_config(mock_nrpe, mock_create_nrpe_check_cmd,
         description="Check servers: all",
         check_cmd="test cmd"
     )
-    mock_create_nrpe_check_cmd.assert_any_call(
-        nrpe_helpers.NRPE_OPENSTACK_INTERFACE, "server", "all", "1,2", True)
+    mock_create_nrpe_check_cmd.assert_any_call(nrpe_helpers.NRPE_CHECKS[6])
     assert mock_nrpe_setup.remove_check.call_count == 7
     mock_nrpe_setup.reset_mock()
     mock_create_nrpe_check_cmd.reset_mock()

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -125,7 +125,7 @@ def test_remove_nrpe_config(mock_remove_nagios_openstack_cnf):
     openstack.remove_nrpe_config()
     mock_nrpe_setup.remove_check.assert_called_once_with(
         shortname="openstack_servers", description="",
-        chech_cmd="/test/check_openstack_interface.py server "
+        check_cmd="/test/check_openstack_interface.py server "
                   "-c /etc/nagios/openstack.cnf --id 1 --id 2 --id 3"
     )
     mock_remove_nagios_openstack_cnf.assert_called_once_with()

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -31,26 +31,26 @@ def test_initial_nrpe_config_failed(mock_update_nrpe_config):
     mock_update_nrpe_config.assert_called_once()
 
 
-@mock.patch("charms.layer.openstack.write_nagios_openstack_cnf")
-def test_update_nrpe_config(mock_write_nagios_openstack_cnf, openstack_config):
+@mock.patch("nrpe_helpers.write_nagios_openstack_cnf")
+def test_update_nrpe_config(mock_write_nagios_openstack_cnf):
     nrpe.NRPE.return_value = mock_nrpe_setup = MagicMock()
     NAGIOS_PLUGINS_DIR.__fspath__.return_value = "/test/"
-    config.return_value = openstack_config
+    config.return_value = mock_config = MagicMock()
 
     # no NRPE checks were added / deleted
-    openstack_config.changed.return_value = False
-    openstack_config.get.side_effect = {}.get
+    mock_config.changed.return_value = False
+    mock_config.get.side_effect = {}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_not_called()
     mock_nrpe_setup.remove_check.assert_not_called()
     mock_write_nagios_openstack_cnf.assert_called_once_with()
     mock_write_nagios_openstack_cnf.reset_mock()
     mock_nrpe_setup.reset_mock()
-    openstack_config.reset_mock()
+    mock_config.reset_mock()
 
     # add NRPE check for kubernetes subnet
-    openstack_config.changed.return_value = True
-    openstack_config.get.side_effect = {"subnet-id": "1234"}.get
+    mock_config.changed.return_value = True
+    mock_config.get.side_effect = {"subnet-id": "1234"}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_called_once_with(
         shortname="kubernetes_subnet",
@@ -60,11 +60,11 @@ def test_update_nrpe_config(mock_write_nagios_openstack_cnf, openstack_config):
     )
     assert mock_nrpe_setup.remove_check.call_count == 7
     mock_nrpe_setup.reset_mock()
-    openstack_config.reset_mock()
+    mock_config.reset_mock()
 
     # add NRPE check for servers
-    openstack_config.changed.return_value = True
-    openstack_config.get.side_effect = {"nrpe-server-ids": "1,2,3"}.get
+    mock_config.changed.return_value = True
+    mock_config.get.side_effect = {"nrpe-server-ids": "1,2,3"}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_called_once_with(
         shortname="openstack_servers",
@@ -74,12 +74,12 @@ def test_update_nrpe_config(mock_write_nagios_openstack_cnf, openstack_config):
     )
     assert mock_nrpe_setup.remove_check.call_count == 7
     mock_nrpe_setup.reset_mock()
-    openstack_config.reset_mock()
+    mock_config.reset_mock()
 
     # add NRPE check for servers with skip-ids
-    openstack_config.changed.return_value = True
-    openstack_config.get.side_effect = {"nrpe-server-ids": "all",
-                                        "nrpe-skip-server-ids": "1,2"}.get
+    mock_config.changed.return_value = True
+    mock_config.get.side_effect = {
+        "nrpe-server-ids": "all", "nrpe-skip-server-ids": "1,2"}.get
     openstack.update_nrpe_config()
     mock_nrpe_setup.add_check.assert_called_once_with(
         shortname="openstack_servers",
@@ -89,32 +89,31 @@ def test_update_nrpe_config(mock_write_nagios_openstack_cnf, openstack_config):
     )
     assert mock_nrpe_setup.remove_check.call_count == 7
     mock_nrpe_setup.reset_mock()
-    openstack_config.reset_mock()
+    mock_config.reset_mock()
 
     # raise a ValueError while adding NRPE check
-    openstack_config.changed.return_value = True
-    openstack_config.get.side_effect = {"nrpe-server-ids": "1,2",
-                                        "nrpe-skip-server-ids": "1"}.get
+    mock_config.changed.return_value = True
+    mock_config.get.side_effect = {
+        "nrpe-server-ids": "1,2", "nrpe-skip-server-ids": "1"}.get
     with pytest.raises(ValueError):
         openstack.update_nrpe_config()
 
-    openstack_config.get.side_effect = {"subnet-id": "all"}.get
+    mock_config.get.side_effect = {"subnet-id": "all"}.get
 
     with pytest.raises(ValueError):
         openstack.update_nrpe_config()
 
-    openstack_config.reset_mock()
+    mock_config.reset_mock()
 
 
-@mock.patch("charms.layer.openstack.remove_nagios_openstack_cnf")
-def test_remove_nrpe_config(mock_remove_nagios_openstack_cnf,
-                            openstack_config):
+@mock.patch("nrpe_helpers.remove_nagios_openstack_cnf")
+def test_remove_nrpe_config(mock_remove_nagios_openstack_cnf):
     nrpe.NRPE.return_value = mock_nrpe_setup = MagicMock()
     NAGIOS_PLUGINS_DIR.__fspath__.return_value = "/test/"
-    config.return_value = openstack_config
+    config.return_value = mock_config = MagicMock()
 
     # no NRPE checks were removed
-    openstack_config.get.side_effect = {}.get
+    mock_config.get.side_effect = {}.get
     openstack.remove_nrpe_config()
     mock_nrpe_setup.remove_check.assert_not_called()
     mock_remove_nagios_openstack_cnf.assert_called_once_with()
@@ -122,7 +121,7 @@ def test_remove_nrpe_config(mock_remove_nagios_openstack_cnf,
     mock_nrpe_setup.reset_mock()
 
     # remove NRPE check for kubernetes network
-    openstack_config.get.side_effect = {"nrpe-server-ids": "1,2,3"}.get
+    mock_config.get.side_effect = {"nrpe-server-ids": "1,2,3"}.get
     openstack.remove_nrpe_config()
     mock_nrpe_setup.remove_check.assert_called_once_with(
         shortname="openstack_servers", description="",

--- a/tests/test_openstack_integrator.py
+++ b/tests/test_openstack_integrator.py
@@ -1,608 +1,98 @@
-import os
-import pytest
-import tempfile
-from base64 import b64encode
-from pathlib import Path
 from unittest import mock
-
-# patched
-import subprocess
-from urllib.request import urlopen
-from time import sleep
-import charms.layer
-
-from charms.unit_test import patch_fixture
-import reactive.openstack
-
-openstack = charms.layer.openstack
-status = charms.layer.status
-
-log_err = patch_fixture('charms.layer.openstack.log_err')
-_load_creds = patch_fixture('charms.layer.openstack._load_creds')
-detect_octavia = patch_fixture('charms.layer.openstack.detect_octavia')
-_run_with_creds = patch_fixture('charms.layer.openstack._run_with_creds')
-_openstack = patch_fixture('charms.layer.openstack._openstack')
-_neutron = patch_fixture('charms.layer.openstack._neutron')
-LoadBalancerClient = patch_fixture('charms.layer.openstack.LoadBalancerClient')
-OctaviaLBClient = patch_fixture('charms.layer.openstack.OctaviaLBClient')
-NeutronLBClient = patch_fixture('charms.layer.openstack.NeutronLBClient')
-_default_subnet = patch_fixture('charms.layer.openstack._default_subnet')
-kv = patch_fixture('charms.layer.openstack.kv')
-config = patch_fixture('charms.layer.openstack.config', {})
-get_port_sec_enabled = patch_fixture('charms.layer.openstack.BaseLBImpl'
-                                     '.get_port_sec_enabled',
-                                     patch_opts={'return_value': True},
-                                     fixture_opts={'autouse': True})
-_normalize_creds = patch_fixture('charms.layer.openstack._normalize_creds')
-_save_creds = patch_fixture('charms.layer.openstack._save_creds')
-_determine_version = patch_fixture('charms.layer.openstack._determine_version')
-
-
-class MockCalledProcessError(Exception):
-    def __init__(self, return_code, stderr):
-        self.stderr = stderr
-
-
-subprocess.CalledProcessError = MockCalledProcessError
-
-
-@pytest.fixture(autouse=True)
-def clean():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cert_file = Path(tmpdir) / 'test.crt'
-        openstack.CA_CERT_FILE = cert_file
-        openstack.config = {}
-        yield
-
-
-@pytest.fixture
-def impl():
-    with mock.patch.object(openstack.LoadBalancer, '_get_impl') as _get_impl:
-        _get_impl.return_value = mock.Mock(spec=openstack.BaseLBImpl)
-        yield _get_impl()
-
-
-def test_determine_version(log_err):
-    assert openstack._determine_version({'version': 3}, None) == '3'
-    assert not urlopen.called
-    assert not log_err.called
-
-    assert openstack._determine_version({}, 'https://endpoint/2') == '2'
-    assert openstack._determine_version({}, 'https://endpoint/v2') == '2'
-    assert openstack._determine_version({}, 'https://endpoint/v2.0') == '2.0'
-    assert not urlopen.called
-    assert not log_err.called
-
-    read = urlopen().__enter__().read
-    read.return_value = (
-        b'{"version": {"id": "v3.12", "status": "stable", '
-        b'"updated": "2019-01-22T00:00:00Z", "links": [{"rel": "self", '
-        b'"href": "http://10.244.40.88:5000/v3/"}], "media-types": [{'
-        b'"base": "application/json", '
-        b'"type": "application/vnd.openstack.identity-v3+json"}]}}')
-    assert openstack._determine_version({}, 'https://endpoint/') == '3'
-    assert not log_err.called
-
-    urlopen.side_effect = ValueError('foo')
-    assert openstack._determine_version({}, 'https://endpoint/') is None
-
-    urlopen.side_effect = None
-    assert openstack._determine_version({}, 'https://endpoint/') == '3'
-
-    read.return_value = b'.'
-    assert openstack._determine_version({}, 'https://endpoint/') is None
-    assert log_err.called
-
-    read.return_value = b'\xff'
-    assert openstack._determine_version({}, 'https://endpoint/') is None
-
-    read.return_value = b'{}'
-    assert openstack._determine_version({}, 'https://endpoint/') is None
-
-
-def _b64(s):
-    return b64encode(s.encode('utf8')).decode('utf8')
-
-
-def test_run_with_creds(_load_creds):
-    _load_creds.return_value = {
-        'auth_url': 'auth_url',
-        'region': 'region',
-        'username': 'username',
-        'password': 'password',
-        'user_domain_name': 'user_domain_name',
-        'project_domain_name': 'project_domain_name',
-        'project_name': 'project_name',
-        'endpoint_tls_ca': _b64('endpoint_tls_ca'),
-        'version': '3',
-    }
-    with mock.patch.dict(os.environ, {'PATH': 'path'}):
-        openstack._run_with_creds('my', 'args')
-    assert openstack.CA_CERT_FILE.exists()
-    assert openstack.CA_CERT_FILE.read_text() == 'endpoint_tls_ca\n'
-    assert subprocess.run.call_args == mock.call(('my', 'args'), env={
-        'PATH': '/snap/bin:path',
-        'OS_AUTH_URL': 'auth_url',
-        'OS_USERNAME': 'username',
-        'OS_PASSWORD': 'password',
-        'OS_REGION_NAME': 'region',
-        'OS_USER_DOMAIN_NAME': 'user_domain_name',
-        'OS_PROJECT_NAME': 'project_name',
-        'OS_PROJECT_DOMAIN_NAME': 'project_domain_name',
-        'OS_IDENTITY_API_VERSION': '3',
-        'OS_CACERT': str(openstack.CA_CERT_FILE),
-    }, check=True, stdout=mock.ANY)
-
-    _load_creds.return_value['endpoint_tls_ca'] = _b64('foo')
-    openstack._run_with_creds('my', 'args')
-    assert openstack.CA_CERT_FILE.read_text() == 'foo\n'
-
-    _load_creds.return_value['endpoint_tls_ca'] = None
-    del openstack._load_creds.return_value['version']
-    openstack._run_with_creds('my', 'args')
-    env = subprocess.run.call_args[1]['env']
-    assert env['OS_CACERT'] == str(openstack.CA_CERT_FILE)
-    assert 'OS_IDENTITY_API_VERSION' not in env
-
-    openstack.CA_CERT_FILE.unlink()
-    _load_creds.return_value['version'] = None
-    openstack._run_with_creds('my', 'args')
-    env = subprocess.run.call_args[1]['env']
-    assert 'OS_CACERT' not in env
-    assert 'OS_IDENTITY_API_VERSION' not in env
-
-
-def test_default_subnet(_openstack):
-    members = [('192.168.0.1', 80), ('10.0.0.1', 80)]
-    _openstack.return_value = [
-        {'Name': 'a', 'Subnet': '192.168.0.0/24'},
-        {'Name': 'b', 'Subnet': '10.0.0.0/16'},
-    ]
-    assert openstack._default_subnet(members) == 'a'
-    assert openstack._default_subnet(list(reversed(members))) == 'b'
-    with pytest.raises(openstack.OpenStackLBError):
-        openstack._default_subnet([('10.1.0.1', 80)])
-
-
-@mock.patch.object(openstack.LoadBalancer, '_add_member_sg')
-@mock.patch.object(openstack.LoadBalancer, '_create_member_sg')
-@mock.patch.object(openstack.LoadBalancer, 'create')
-def test_get_or_create(create, cms, ams, kv):
-    args = ('app', '80', 'subnet', 'alg', None, False)
-    kv().get.return_value = {'sg_id': 'sg_id',
-                             'member_sg_id': 'member_sg_id',
-                             'fip': 'fip',
-                             'address': 'address',
-                             'members': [[1, 2], [3, 4]]}
-    lb = openstack.LoadBalancer.get_or_create(*args)
-    assert not create.called
-    assert lb.name == 'openstack-integrator-1234-app'
-    assert lb.port == '80'
-    assert lb.subnet == 'subnet'
-    assert lb.algorithm == 'alg'
-    assert lb.fip_net is None
-    assert lb.manage_secgrps is False
-    assert lb._key == 'created_lbs.openstack-integrator-1234-app'
-    assert lb.sg_id == 'sg_id'
-    assert lb.member_sg_id == 'member_sg_id'
-    assert lb.fip == 'fip'
-    assert lb.address == 'address'
-    assert lb.members == {(1, 2), (3, 4)}
-    assert lb.is_created is True
-    assert not cms.called
-    assert not ams.called
-
-    del kv().get.return_value['member_sg_id']
-    lb = openstack.LoadBalancer.get_or_create(*args)
-    assert cms.called
-    assert ams.called
-
-    cms.reset_mock()
-    ams.reset_mock()
-    kv().get.return_value = None
-    lb = openstack.LoadBalancer.get_or_create(*args)
-    assert create.called
-    assert lb.sg_id is None
-    assert lb.fip is None
-    assert lb.address is None
-    assert lb.members == set()
-    assert not cms.called
-    assert not ams.called
-
-    create.side_effect = subprocess.CalledProcessError(1, 'cmd')
-    with pytest.raises(openstack.OpenStackLBError):
-        openstack.LoadBalancer.get_or_create(*args)
-
-
-def test_create_new(impl, log_err):
-    openstack.kv().get.return_value = None
-    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
-    assert not lb.is_created
-    lb.name = 'name'
-    impl.list_loadbalancers.return_value = []
-    impl.create_loadbalancer.return_value = {'id': '1234',
-                                             'vip_address': '1.1.1.1',
-                                             'vip_port_id': '4321'}
-    impl.show_loadbalancer.return_value = {'provisioning_status': 'ACTIVE'}
-    impl.show_pool.return_value = {'provisioning_status': 'ACTIVE'}
-    impl.find_secgrp.side_effect = ['sg_id', 'member_sg_id']
-    impl.list_listeners.return_value = []
-    impl.list_pools.return_value = []
-    impl.list_members.return_value = [('member', '6443')]
-    impl.list_sg_rules.return_value = []
-    impl.get_port_sec_enabled.return_value = True
-    impl.get_subnet_cidr.return_value = '1.1.1.1/32'
-    impl.create_secgrp.return_value = 'member_sg_id'
-    lb.create()
-    assert lb.sg_id is None
-    assert lb.member_sg_id == 'member_sg_id'
-    assert lb.fip is None
-    assert lb.address == '1.1.1.1'
-    assert lb.members == [('member', '6443')]
-    assert lb.is_created
-    assert impl.create_loadbalancer.called
-    assert not impl.create_secgrp.called
-    assert not impl.set_port_secgrp.called
-    assert impl.create_listener.called
-    assert impl.create_pool.called
-    assert not impl.list_fips.called
-    assert not impl.create_fip.called
-
-    impl.find_secgrp.side_effect = ['sg_id', None]
-    lb.create()
-    impl.create_secgrp.assert_called_with('name-members')
-
-    impl.find_secgrp.side_effect = None
-    impl.find_secgrp.return_value = None
-    with pytest.raises(openstack.OpenStackLBError):
-        lb.create()
-    openstack.log_err.assert_called_with('Unable to find default '
-                                         'security group')
-
-    lb.fip_net = 'net'
-    lb.manage_secgrps = True
-    impl.create_secgrp.return_value = 'sg_id'
-    impl.list_fips.return_value = []
-    lb.create()
-    assert lb.sg_id == 'sg_id'
-    impl.create_secgrp.assert_has_calls([
-        mock.call('name'), mock.call('name-members')])
-    impl.set_port_secgrp.assert_called_with('4321', 'sg_id')
-    impl.create_fip.assert_called_with('1.1.1.1', '4321')
-
-
-def test_create_recover(impl):
-    openstack.kv().get.return_value = None
-    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', 'net', True)
-    lb.name = 'name'
-    impl.list_loadbalancers.return_value = [{'name': 'name'}]
-    impl.show_loadbalancer.return_value = {'id': '2345',
-                                           'provisioning_status': 'ACTIVE',
-                                           'vip_address': '1.1.1.1',
-                                           'vip_port_id': '4321'}
-    impl.find_secgrp.return_value = 'sg_id'
-    impl.list_sg_rules.return_value = [{'Port Range': '', 'IP Range': ''}]
-    impl.get_port_sec_enabled.return_value = False
-    impl.list_listeners.return_value = [{'name': 'name'}]
-    impl.list_pools.return_value = [{'name': 'name'}]
-    impl.list_fips.return_value = [
-        {'Fixed IP Address': '2.2.2.2', 'Floating IP Address': '3.3.3.3'},
-        {'Fixed IP Address': '1.1.1.1', 'Floating IP Address': '4.4.4.4'},
-    ]
-    impl.list_members.return_value = ['members']
-    lb.create()
-    assert lb.sg_id is None
-    assert lb.fip == '4.4.4.4'
-    assert lb.address == '1.1.1.1'
-    assert lb.members == ['members']
-    assert lb.is_created
-    assert not impl.create_loadbalancer.called
-    assert not impl.create_secgrp.called
-    assert not impl.create_listener.called
-    assert not impl.create_pool.called
-    assert not impl.create_fip.called
-
-
-def test_wait_not_pending(impl):
-    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
-    test_func = mock.Mock(side_effect=[
-        {'provisioning_status': 'PENDING_CREATE'},
-        {'provisioning_status': 'PENDING_UPDATE'},
-        {'provisioning_status': 'PENDING_DELETE'},
-        {'provisioning_status': 'ACTIVE'},
-    ])
-    lb._wait_not_pending(test_func)
-    assert sleep.call_count == 3
-
-    test_func = mock.Mock(return_value={
-        'provisioning_status': 'PENDING_DELETE',
-    })
-    with pytest.raises(openstack.OpenStackLBError):
-        lb._wait_not_pending(test_func)
-
-
-def test_find_matching_sg_rule(impl):
-    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
-    lb.address = '1.1.1.1'
-
-    impl.list_sg_rules.return_value = [{'Port Range': None,
-                                        'IP Range': None}]
-    assert lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
-
-    impl.list_sg_rules.return_value = [{'Port Range': '60:90',
-                                        'IP Range': ''}]
-    assert lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
-
-    impl.list_sg_rules.return_value = [{'Port Range': '',
-                                        'IP Range': '1.0.0.0/8'}]
-    assert lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
-
-    impl.list_sg_rules.return_value = [{'Port Range': '81:90',
-                                        'IP Range': ''},
-                                       {'Port Range': '',
-                                        'IP Range': '2.0.0.0/8'}]
-    assert not lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
-
-    impl.list_sg_rules.return_value = []
-    assert not lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
-
-
-def test_find(impl, log_err):
-    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
-    lb.name = 'lb'
-    item1 = {'id': 1, 'name': 'not-lb'}
-    item2 = {'id': 2, 'name': 'lb'}
-    item3 = {'id': 3, 'name': 'lb'}
-    assert lb._find('foo', [item1]) is None
-    assert lb._find('foo', [item1, item2]) == item2
-    with pytest.raises(openstack.OpenStackLBError):
-        lb._find('foo', [item1, item2, item3])
-    log_err.assert_called_with('Multiple {} found: {}', 'foo', 'lb')
-
-
-def test_update_members(impl, _openstack):
-    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
-    lb.address = '1.1.1.1'
-    impl.show_pool.return_value = {'provisioning_status': 'ACTIVE'}
-    impl.list_sg_rules.return_value = []
-    lb.members = {(1, 2), (3, 4)}
-    lb.update_members({(1, 2), (3, 4)})
-    assert not impl.delete_member.called
-    assert not impl.create_member.called
-    assert not impl.create_sg_rule.called
-
-    lb.members = {(1, 2), (3, 4)}
-    lb.update_members({(1, 2), (3, 4), (5, 6)})
-    assert not impl.delete_member.called
-    assert impl.create_member.called
-    assert lb.members == {(1, 2), (3, 4), (5, 6)}
-    assert impl.create_sg_rule.called
-
-    impl.create_member.reset_mock()
-    impl.create_sg_rule.reset_mock()
-    lb.members = {(1, 2), (3, 4)}
-    lb.update_members({(1, 2)})
-    assert impl.delete_member.called
-    assert not impl.create_member.called
-    assert not impl.create_sg_rule.called
-
-    impl.delete_member.reset_mock()
-    lb.members = {(1, 2), (3, 4)}
-    lb.update_members({(5, 6)})
-    assert impl.delete_member.called
-    assert impl.create_member.called
-
-    impl.delete_member.side_effect = subprocess.CalledProcessError(1, 'cmd')
-    lb.members = {(1, 2), (3, 4)}
-    with pytest.raises(openstack.OpenStackLBError):
-        lb.update_members(set())
-
-    impl.delete_member.side_effect = AssertionError('should not be called')
-    impl.create_member.side_effect = subprocess.CalledProcessError(1, 'cmd')
-    lb.members = set()
-    with pytest.raises(openstack.OpenStackLBError):
-        lb.update_members({(1, 2)})
-
-
-def test_is_base64():
-    cert = ('-----BEGIN CERTIFICATE-----\nMIIDITCCAgmgAwIBAgIUeQxHSsZt6auk1oW+'
-            'SRFXC4T6nNcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVUsxETAPBgNVBAo'
-            'MCElubWFyc2F0MB4XDTE5MTEwNDE1\nMTQzOFoXDTI5MTEwMTE1MTQzOFowIDELMA'
-            'kGA1UEBhMCVUsxETAPBgNVBAoMCElu\nbWFyc2F0MIIBIjANBgkqhkiG9w0BAQEFA'
-            'AOCAQ8AMIIBCgKCAQEA09qCmv8jF+N1\ndl/ae3VQV95FG7WFrjS6fbZ1TpXkO9Vs'
-            'PKhA9lRUBxs58noKIkMIUeXYy4wvSu28\nX67NqB2bv3iyns/mEzPYE1GxtFXIPhk'
-            'KO22vqVLZ0CFAuV47AhqDOXtyqwwfxoBT\nKxMi430UCb+3cPaev/mZMlvf6iJfdi'
-            'hyPfMEwtIanS/QKgEvykhP1kAZ36ActFmK\nWnJtjBBFUKQIBQzguMTqUXX7wvwRe'
-            'gK8lgXiZ6iZiOza0C7hSdBVylcKeaqoLnP5\nW93m3YZTXc08A30PieTJQFD6Bm+4'
-            '1Kv2FxQAXjRnCzvIJL44zJXjLmnUdZbSzdl8\nPpu3wJu9cQIDAQABo1MwUTAdBgN'
-            'VHQ4EFgQUwQsYIyqud2WQkAlcDwIuu7nAvnYw\nHwYDVR0jBBgwFoAUwQsYIyqud2'
-            'WQkAlcDwIuu7nAvnYwDwYDVR0TAQH/BAUwAwEB\n/zANBgkqhkiG9w0BAQsFAAOCA'
-            'QEAn5oQYeyaxcqOjzUxbkEy4pOJMg/nTKkt+8yh\nFSqUv1Vc3HGg65uGq08eJDq9'
-            'AP7PrfvSQJWQpFBS80bNN8idCmhMutpA8X6+Z0wv\n0p5dzQFAUdSLLN0so4iXKtP'
-            'k5wp0r84W0xbqWPRWRSw+lCe1WrMK+ARDpPv+AxOW\nf7JFQkqzEsWu6RCjy0KobO'
-            'y7PPq17wXEhXynNcMAXjQe9DkTBb34K6PYku1Ftxfr\n3IRWaSrDB9BJTje6/tmz7'
-            'IcO8ss+Y3gUZeaqTLdZz8RJUlJqNqfdTQif2hKLYjro\nBwZYRQo8TkDmSlz00LwQ'
-            'So1xLX27nGHB621pgNCZbJMKvZOrQg==\n-----END CERTIFICATE-----\n')
-    cert = cert.encode('utf8')
-    assert openstack._is_base64(cert) is False
-    # Base64 encoded foobar string
-    foobar = 'Zm9vYmFyCg==\n'.encode('utf8')
-    assert openstack._is_base64(foobar)
-
-
-def test_series_upgrade():
-    assert charms.layer.status.blocked.call_count == 0
-    reactive.openstack.pre_series_upgrade()
-    assert charms.layer.status.blocked.call_count == 1
-
-
-def test_get_credentials(_normalize_creds, _save_creds, log_err):
-    openstack.hookenv.config.return_value = config = {
-        'credentials': None,
-    }
-    subprocess.run.side_effect = MockCalledProcessError(1, b'foo')
-    with pytest.raises(MockCalledProcessError):
-        openstack.get_credentials()
-
-    subprocess.run.side_effect = MockCalledProcessError(1,
-                                                        b'permission denied')
-    _normalize_creds.side_effect = ValueError('unsupported auth-type')
-    assert openstack.get_credentials() is False
-    status.blocked.assert_called_with('unsupported auth-type')
-
-    _normalize_creds.reset_mock()
-    status.blocked.reset_mock()
-    subprocess.run.side_effect = FileNotFoundError()
-    assert openstack.get_credentials() is False
-    status.blocked.assert_called_with('unsupported auth-type')
-    assert _normalize_creds.call_args_list == [
-        mock.call({'credentials': None}),
-    ]
-
-    status.blocked.reset_mock()
-    _normalize_creds.reset_mock()
-    _normalize_creds.side_effect = lambda a: a
-    stdout = b'{}'
-    subprocess.run.side_effect = lambda *a, **k: mock.Mock(stdout=stdout)
-    assert openstack.get_credentials() is False
-    status.blocked.assert_called_with(
-        'missing credentials; grant with `juju trust` or set via config')
-    assert _normalize_creds.call_args_list == [
-        mock.call({}),
-        mock.call({'credentials': None}),
-    ]
-
-    _normalize_creds.reset_mock()
-    stdout = b'{"foo": "bar"}'
-    assert openstack.get_credentials() is False
-    assert _normalize_creds.call_args_list == [
-        mock.call({'foo': 'bar'}),
-        mock.call({'credentials': None}),
-    ]
-
-    status.blocked.reset_mock()
-    subprocess.run.side_effect = FileNotFoundError()
-    config['credentials'] = 'foo'
-    assert openstack.get_credentials() is False
-    status.blocked.assert_called_with(
-        'invalid value for credentials config: Incorrect padding')
-
-    status.blocked.reset_mock()
-    subprocess.run.side_effect = FileNotFoundError()
-    config['credentials'] = 'ewo='
-    assert openstack.get_credentials() is False
-    status.blocked.assert_called_with(
-        'invalid value for credentials config: Expecting property name '
-        'enclosed in double quotes: line 2 column 1 (char 2)')
-
-    _normalize_creds.reset_mock()
-    subprocess.run.side_effect = FileNotFoundError()
-    config['credentials'] = 'eyJmb28iOiAiYmFyIn0K'
-    assert openstack.get_credentials() is False
-    assert _normalize_creds.call_args_list == [
-        mock.call({'foo': 'bar'}),
-        mock.call({'credentials': 'eyJmb28iOiAiYmFyIn0K'}),
-    ]
-
-    config.update({
-        'credentials': None,
-        'auth_url': 'auth-url',
-        'region': 'region',
-        'username': 'username',
-        'password': 'password',
-        'user_domain_name': 'user-domain-name',
-        'project_domain_name': 'project-domain-name',
-        'project_name': 'project-name',
-    })
-    expected = config.copy()
-    del expected['credentials']
-    expected['endpoint_tls_ca'] = ''
-    assert openstack.get_credentials() is True
-    _save_creds.assert_called_with(expected)
-
-    _save_creds.reset_mock()
-    status.blocked.reset_mock()
-    config['region'] = ''
-    assert openstack.get_credentials() is False
-    assert not _save_creds.called
-    status.blocked.assert_called_with('missing required credential: region')
-
-    status.blocked.reset_mock()
-    config['username'] = ''
-    assert openstack.get_credentials() is False
-    status.blocked.assert_called_with('missing required credentials: '
-                                      'region, username')
-
-
-def test_normalize_creds(_determine_version, log_err):
-    _determine_version.return_value = '3'
-    with pytest.raises(ValueError) as excinfo:
-        openstack._normalize_creds({'auth-type': 'allow'})
-    assert str(excinfo.value) == 'unsupported auth-type in credentials: allow'
-    with pytest.raises(ValueError) as excinfo:
-        openstack._normalize_creds({
-            'endpoint': '/',
-            'credential': {
-                'attributes': {
-                    'auth-type': 'allow',
-                },
-            },
-        })
-    assert str(excinfo.value) == 'unsupported auth-type in credentials: allow'
-    assert openstack._normalize_creds({}) == dict(
-        auth_url='',
-        region='',
-        username=None,
-        password=None,
-        user_domain_name=None,
-        project_domain_name=None,
-        project_name=None,
-        endpoint_tls_ca=None,
-        version='3',
+from unittest.mock import MagicMock
+
+import nrpe_helpers
+
+from reactive import openstack
+from charms.reactive import is_flag_set
+
+
+@mock.patch("reactive.openstack.update_nrpe_config")
+def test_initial_nrpe_config(mock_update_nrpe_config):
+    openstack.initial_nrpe_config()
+    assert is_flag_set("nrpe-external-master.initial-config")
+    mock_update_nrpe_config.assert_called_once()
+
+
+@mock.patch("charms.layer.openstack._get_creds_env")
+@mock.patch("charms.layer.openstack.create_nrpe_check_cmd")
+@mock.patch("charmhelpers.contrib.charmsupport.nrpe.NRPE")
+def test_update_nrpe_config(mock_nrpe, mock_create_nrpe_check_cmd,
+                            mock_get_creds_env, config):
+    mock_create_nrpe_check_cmd.return_value = "test cmd"
+    mock_nrpe_setup = MagicMock()
+    mock_nrpe.return_value = mock_nrpe_setup
+    mock_get_creds_env.return_value = {}
+
+    # no NRPE checks were added
+    openstack.update_nrpe_config()
+    mock_nrpe_setup.add_check.assert_not_called()
+    assert mock_nrpe_setup.remove_check.call_count == 8
+    mock_nrpe_setup.reset_mock()
+
+    # add NRPE check for kubernetes subnet
+    config.get.side_effect = lambda k: {"subnet-id": "1234"}.get(k)
+    openstack.update_nrpe_config()
+    mock_nrpe_setup.add_check.assert_called_once_with(
+        shortname="kubernetes_subnet",
+        description="Check subnets: 1234",
+        check_cmd="test cmd"
     )
-    _determine_version.assert_called_with({}, '')
-    attrs = {
-        'auth-url': 'auth-url',
-        'region': 'us-east-1',
-        'username': 'username',
-        'password': 'password',
-        'user-domain-name': 'user-domain-name',
-        'project-domain-name': 'project-domain-name',
-        'tenant-name': 'tenant-name',
-    }
-    expected = dict(
-        auth_url='auth-url',
-        region='us-east-1',
-        username='username',
-        password='password',
-        user_domain_name='user-domain-name',
-        project_domain_name='project-domain-name',
-        project_name='tenant-name',
-        endpoint_tls_ca=None,
-        version='3',
+    assert mock_nrpe_setup.remove_check.call_count == 7
+    mock_create_nrpe_check_cmd.assert_any_call(
+        nrpe_helpers.NRPE_OPENSTACK_INTERFACE, "subnet", "1234", None, False)
+    mock_nrpe_setup.reset_mock()
+    mock_create_nrpe_check_cmd.reset_mock()
+
+    # add NRPE check for servers
+    config.get.side_effect = lambda k: {"nrpe-server-ids": "1,2,3"}.get(k)
+    openstack.update_nrpe_config()
+    mock_nrpe_setup.add_check.assert_called_once_with(
+        shortname="openstack_servers",
+        description="Check servers: 1,2,3",
+        check_cmd="test cmd"
     )
-    assert openstack._normalize_creds(attrs) == expected
-    assert openstack._normalize_creds({
-        'endpoint': 'endpoint',
-        'region': 'region',
-        'credential': {'attributes': attrs},
-    }) == dict(expected, auth_url='endpoint', region='region')
+    mock_create_nrpe_check_cmd.assert_any_call(
+        nrpe_helpers.NRPE_OPENSTACK_INTERFACE, "server", "1,2,3", None, True)
+    assert mock_nrpe_setup.remove_check.call_count == 7
+    mock_nrpe_setup.reset_mock()
+    mock_create_nrpe_check_cmd.reset_mock()
 
-    attrs['project-name'] = expected['project_name'] = 'project-name'
-    assert openstack._normalize_creds(attrs) == expected
+    # add NRPE check for networks with skip-ids
+    test_config = {"nrpe-server-ids": "all", "nrpe-skip-server-ids": "1,2"}
+    config.get.side_effect = lambda k: test_config.get(k)
+    openstack.update_nrpe_config()
+    mock_nrpe_setup.add_check.assert_called_once_with(
+        shortname="openstack_servers",
+        description="Check servers: all",
+        check_cmd="test cmd"
+    )
+    mock_create_nrpe_check_cmd.assert_any_call(
+        nrpe_helpers.NRPE_OPENSTACK_INTERFACE, "server", "all", "1,2", True)
+    assert mock_nrpe_setup.remove_check.call_count == 7
+    mock_nrpe_setup.reset_mock()
+    mock_create_nrpe_check_cmd.reset_mock()
 
-    attrs['ca-certificates'] = []
-    assert openstack._normalize_creds(attrs) == expected
 
-    attrs['ca-certificates'] = ['ca-cert']
-    expected['endpoint_tls_ca'] = 'Y2EtY2VydA=='
-    assert openstack._normalize_creds(attrs) == expected
+@mock.patch("charms.layer.openstack._get_creds_env")
+@mock.patch("charms.layer.openstack.create_nrpe_check_cmd")
+@mock.patch("charmhelpers.contrib.charmsupport.nrpe.NRPE")
+def test_remove_nrpe_config(mock_nrpe, mock_create_nrpe_check_cmd,
+                            mock_get_creds_env, config):
+    mock_create_nrpe_check_cmd.return_value = "test cmd"
+    mock_nrpe_setup = MagicMock()
+    mock_nrpe.return_value = mock_nrpe_setup
+    mock_get_creds_env.return_value = {}
 
-    attrs['ca-certificates'] = ['Y2EtY2VydA==']
-    assert openstack._normalize_creds(attrs) == expected
+    # no NRPE checks were removed
+    openstack.remove_nrpe_config()
+    mock_nrpe_setup.remove_check.assert_not_called()
+    mock_nrpe_setup.reset_mock()
 
-    attrs['cacertificates'] = attrs.pop('ca-certificates')
-    assert openstack._normalize_creds(attrs) == expected
-
-    attrs['endpoint-tls-ca'] = attrs.pop('cacertificates')[0]
-    assert openstack._normalize_creds(attrs) == expected
+    # remove NRPE check for kubernetes network
+    config.get.side_effect = lambda k: {"floating-network-id": "1"}.get(k)
+    openstack.remove_nrpe_config()
+    mock_nrpe_setup.remove_check.assert_called_with(
+        shortname="kubernetes_network", description="", chech_cmd="test cmd"
+    )
+    mock_nrpe_setup.reset_mock()

--- a/tests/test_openstack_integrator_lib.py
+++ b/tests/test_openstack_integrator_lib.py
@@ -11,7 +11,6 @@ from urllib.request import urlopen
 from time import sleep
 
 import charms.layer
-import nrpe_helpers
 
 import reactive.openstack
 
@@ -587,39 +586,3 @@ def test_normalize_creds(_determine_version, log_err):
 
     attrs['endpoint-tls-ca'] = attrs.pop('cacertificates')[0]
     assert openstack._normalize_creds(attrs) == expected
-
-
-@pytest.mark.parametrize("ids,skip_ids,check_all,exp_cmd", [
-    ("1,2", "", False, "--id 1 --id 2"),
-    ("all", "1,2", True, "--all --skip-id 1 --skip-id 2"),
-    ("all", "1,2", True, "--all --skip-id 1 --skip-id 2"),
-])
-def test_create_nrpe_check_cmd(
-        ids, skip_ids, check_all, exp_cmd, openstack_config):
-    """Test creating cmd for NRPE check."""
-    openstack_config.get.side_effect = lambda x: {
-        "nrpe_check_cmd-ids": ids, "nrpe_check_cmd-skip-ids": skip_ids,
-    }.get(x)
-    check = nrpe_helpers.NrpeCheck("test", "test", "nrpe_check_cmd-ids",
-                                   "nrpe_check_cmd-skip-ids", check_all)
-
-    cmd = openstack.create_nrpe_check_cmd(check)
-
-    assert exp_cmd in cmd
-
-
-@pytest.mark.parametrize("ids,skip_ids,check_all", [
-    ("all", "", False),
-    ("1,2", "1", True),
-])
-def test_create_nrpe_check_cmd_error(
-        ids, skip_ids, check_all, openstack_config):
-    """Test creating cmd for NRPE check."""
-    openstack_config.get.side_effect = lambda x: {
-        "nrpe_check_cmd-ids": ids, "nrpe_check_cmd-skip-ids": skip_ids,
-    }.get(x)
-    check = nrpe_helpers.NrpeCheck("test", "test", "nrpe_check_cmd-ids",
-                                   "nrpe_check_cmd-skip-ids", check_all)
-
-    with pytest.raises(ValueError):
-        openstack.create_nrpe_check_cmd(check)

--- a/tests/test_openstack_integrator_lib.py
+++ b/tests/test_openstack_integrator_lib.py
@@ -1,0 +1,632 @@
+import os
+import pytest
+import tempfile
+from base64 import b64encode
+from pathlib import Path
+from unittest import mock
+
+# patched
+import subprocess
+from urllib.request import urlopen
+from time import sleep
+import charms.layer
+
+from charms.unit_test import patch_fixture
+import reactive.openstack
+
+openstack = charms.layer.openstack
+status = charms.layer.status
+
+log_err = patch_fixture('charms.layer.openstack.log_err')
+_load_creds = patch_fixture('charms.layer.openstack._load_creds')
+detect_octavia = patch_fixture('charms.layer.openstack.detect_octavia')
+_run_with_creds = patch_fixture('charms.layer.openstack._run_with_creds')
+_openstack = patch_fixture('charms.layer.openstack._openstack')
+_neutron = patch_fixture('charms.layer.openstack._neutron')
+LoadBalancerClient = patch_fixture('charms.layer.openstack.LoadBalancerClient')
+OctaviaLBClient = patch_fixture('charms.layer.openstack.OctaviaLBClient')
+NeutronLBClient = patch_fixture('charms.layer.openstack.NeutronLBClient')
+_default_subnet = patch_fixture('charms.layer.openstack._default_subnet')
+kv = patch_fixture('charms.layer.openstack.kv')
+config = patch_fixture('charms.layer.openstack.config', {})
+get_port_sec_enabled = patch_fixture('charms.layer.openstack.BaseLBImpl'
+                                     '.get_port_sec_enabled',
+                                     patch_opts={'return_value': True},
+                                     fixture_opts={'autouse': True})
+_normalize_creds = patch_fixture('charms.layer.openstack._normalize_creds')
+_save_creds = patch_fixture('charms.layer.openstack._save_creds')
+_determine_version = patch_fixture('charms.layer.openstack._determine_version')
+
+
+class MockCalledProcessError(Exception):
+    def __init__(self, return_code, stderr):
+        self.stderr = stderr
+
+
+subprocess.CalledProcessError = MockCalledProcessError
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cert_file = Path(tmpdir) / 'test.crt'
+        openstack.CA_CERT_FILE = cert_file
+        openstack.config = {}
+        yield
+
+
+@pytest.fixture
+def impl():
+    with mock.patch.object(openstack.LoadBalancer, '_get_impl') as _get_impl:
+        _get_impl.return_value = mock.Mock(spec=openstack.BaseLBImpl)
+        yield _get_impl()
+
+
+def test_determine_version(log_err):
+    assert openstack._determine_version({'version': 3}, None) == '3'
+    assert not urlopen.called
+    assert not log_err.called
+
+    assert openstack._determine_version({}, 'https://endpoint/2') == '2'
+    assert openstack._determine_version({}, 'https://endpoint/v2') == '2'
+    assert openstack._determine_version({}, 'https://endpoint/v2.0') == '2.0'
+    assert not urlopen.called
+    assert not log_err.called
+
+    read = urlopen().__enter__().read
+    read.return_value = (
+        b'{"version": {"id": "v3.12", "status": "stable", '
+        b'"updated": "2019-01-22T00:00:00Z", "links": [{"rel": "self", '
+        b'"href": "http://10.244.40.88:5000/v3/"}], "media-types": [{'
+        b'"base": "application/json", '
+        b'"type": "application/vnd.openstack.identity-v3+json"}]}}')
+    assert openstack._determine_version({}, 'https://endpoint/') == '3'
+    assert not log_err.called
+
+    urlopen.side_effect = ValueError('foo')
+    assert openstack._determine_version({}, 'https://endpoint/') is None
+
+    urlopen.side_effect = None
+    assert openstack._determine_version({}, 'https://endpoint/') == '3'
+
+    read.return_value = b'.'
+    assert openstack._determine_version({}, 'https://endpoint/') is None
+    assert log_err.called
+
+    read.return_value = b'\xff'
+    assert openstack._determine_version({}, 'https://endpoint/') is None
+
+    read.return_value = b'{}'
+    assert openstack._determine_version({}, 'https://endpoint/') is None
+
+
+def _b64(s):
+    return b64encode(s.encode('utf8')).decode('utf8')
+
+
+def test_run_with_creds(_load_creds):
+    _load_creds.return_value = {
+        'auth_url': 'auth_url',
+        'region': 'region',
+        'username': 'username',
+        'password': 'password',
+        'user_domain_name': 'user_domain_name',
+        'project_domain_name': 'project_domain_name',
+        'project_name': 'project_name',
+        'endpoint_tls_ca': _b64('endpoint_tls_ca'),
+        'version': '3',
+    }
+    with mock.patch.dict(os.environ, {'PATH': 'path'}):
+        openstack._run_with_creds('my', 'args')
+    assert openstack.CA_CERT_FILE.exists()
+    assert openstack.CA_CERT_FILE.read_text() == 'endpoint_tls_ca\n'
+    assert subprocess.run.call_args == mock.call(('my', 'args'), env={
+        'PATH': '/snap/bin:path',
+        'OS_AUTH_URL': 'auth_url',
+        'OS_USERNAME': 'username',
+        'OS_PASSWORD': 'password',
+        'OS_REGION_NAME': 'region',
+        'OS_USER_DOMAIN_NAME': 'user_domain_name',
+        'OS_PROJECT_NAME': 'project_name',
+        'OS_PROJECT_DOMAIN_NAME': 'project_domain_name',
+        'OS_IDENTITY_API_VERSION': '3',
+        'OS_CACERT': str(openstack.CA_CERT_FILE),
+    }, check=True, stdout=mock.ANY)
+
+    _load_creds.return_value['endpoint_tls_ca'] = _b64('foo')
+    openstack._run_with_creds('my', 'args')
+    assert openstack.CA_CERT_FILE.read_text() == 'foo\n'
+
+    _load_creds.return_value['endpoint_tls_ca'] = None
+    del openstack._load_creds.return_value['version']
+    openstack._run_with_creds('my', 'args')
+    env = subprocess.run.call_args[1]['env']
+    assert env['OS_CACERT'] == str(openstack.CA_CERT_FILE)
+    assert 'OS_IDENTITY_API_VERSION' not in env
+
+    openstack.CA_CERT_FILE.unlink()
+    _load_creds.return_value['version'] = None
+    openstack._run_with_creds('my', 'args')
+    env = subprocess.run.call_args[1]['env']
+    assert 'OS_CACERT' not in env
+    assert 'OS_IDENTITY_API_VERSION' not in env
+
+
+def test_default_subnet(_openstack):
+    members = [('192.168.0.1', 80), ('10.0.0.1', 80)]
+    _openstack.return_value = [
+        {'Name': 'a', 'Subnet': '192.168.0.0/24'},
+        {'Name': 'b', 'Subnet': '10.0.0.0/16'},
+    ]
+    assert openstack._default_subnet(members) == 'a'
+    assert openstack._default_subnet(list(reversed(members))) == 'b'
+    with pytest.raises(openstack.OpenStackLBError):
+        openstack._default_subnet([('10.1.0.1', 80)])
+
+
+@mock.patch.object(openstack.LoadBalancer, '_add_member_sg')
+@mock.patch.object(openstack.LoadBalancer, '_create_member_sg')
+@mock.patch.object(openstack.LoadBalancer, 'create')
+def test_get_or_create(create, cms, ams, kv):
+    args = ('app', '80', 'subnet', 'alg', None, False)
+    kv().get.return_value = {'sg_id': 'sg_id',
+                             'member_sg_id': 'member_sg_id',
+                             'fip': 'fip',
+                             'address': 'address',
+                             'members': [[1, 2], [3, 4]]}
+    lb = openstack.LoadBalancer.get_or_create(*args)
+    assert not create.called
+    assert lb.name == 'openstack-integrator-1234-app'
+    assert lb.port == '80'
+    assert lb.subnet == 'subnet'
+    assert lb.algorithm == 'alg'
+    assert lb.fip_net is None
+    assert lb.manage_secgrps is False
+    assert lb._key == 'created_lbs.openstack-integrator-1234-app'
+    assert lb.sg_id == 'sg_id'
+    assert lb.member_sg_id == 'member_sg_id'
+    assert lb.fip == 'fip'
+    assert lb.address == 'address'
+    assert lb.members == {(1, 2), (3, 4)}
+    assert lb.is_created is True
+    assert not cms.called
+    assert not ams.called
+
+    del kv().get.return_value['member_sg_id']
+    lb = openstack.LoadBalancer.get_or_create(*args)
+    assert cms.called
+    assert ams.called
+
+    cms.reset_mock()
+    ams.reset_mock()
+    kv().get.return_value = None
+    lb = openstack.LoadBalancer.get_or_create(*args)
+    assert create.called
+    assert lb.sg_id is None
+    assert lb.fip is None
+    assert lb.address is None
+    assert lb.members == set()
+    assert not cms.called
+    assert not ams.called
+
+    create.side_effect = subprocess.CalledProcessError(1, 'cmd')
+    with pytest.raises(openstack.OpenStackLBError):
+        openstack.LoadBalancer.get_or_create(*args)
+
+
+def test_create_new(impl, log_err):
+    openstack.kv().get.return_value = None
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    assert not lb.is_created
+    lb.name = 'name'
+    impl.list_loadbalancers.return_value = []
+    impl.create_loadbalancer.return_value = {'id': '1234',
+                                             'vip_address': '1.1.1.1',
+                                             'vip_port_id': '4321'}
+    impl.show_loadbalancer.return_value = {'provisioning_status': 'ACTIVE'}
+    impl.show_pool.return_value = {'provisioning_status': 'ACTIVE'}
+    impl.find_secgrp.side_effect = ['sg_id', 'member_sg_id']
+    impl.list_listeners.return_value = []
+    impl.list_pools.return_value = []
+    impl.list_members.return_value = [('member', '6443')]
+    impl.list_sg_rules.return_value = []
+    impl.get_port_sec_enabled.return_value = True
+    impl.get_subnet_cidr.return_value = '1.1.1.1/32'
+    impl.create_secgrp.return_value = 'member_sg_id'
+    lb.create()
+    assert lb.sg_id is None
+    assert lb.member_sg_id == 'member_sg_id'
+    assert lb.fip is None
+    assert lb.address == '1.1.1.1'
+    assert lb.members == [('member', '6443')]
+    assert lb.is_created
+    assert impl.create_loadbalancer.called
+    assert not impl.create_secgrp.called
+    assert not impl.set_port_secgrp.called
+    assert impl.create_listener.called
+    assert impl.create_pool.called
+    assert not impl.list_fips.called
+    assert not impl.create_fip.called
+
+    impl.find_secgrp.side_effect = ['sg_id', None]
+    lb.create()
+    impl.create_secgrp.assert_called_with('name-members')
+
+    impl.find_secgrp.side_effect = None
+    impl.find_secgrp.return_value = None
+    with pytest.raises(openstack.OpenStackLBError):
+        lb.create()
+    openstack.log_err.assert_called_with('Unable to find default '
+                                         'security group')
+
+    lb.fip_net = 'net'
+    lb.manage_secgrps = True
+    impl.create_secgrp.return_value = 'sg_id'
+    impl.list_fips.return_value = []
+    lb.create()
+    assert lb.sg_id == 'sg_id'
+    impl.create_secgrp.assert_has_calls([
+        mock.call('name'), mock.call('name-members')])
+    impl.set_port_secgrp.assert_called_with('4321', 'sg_id')
+    impl.create_fip.assert_called_with('1.1.1.1', '4321')
+
+
+def test_create_recover(impl):
+    openstack.kv().get.return_value = None
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', 'net', True)
+    lb.name = 'name'
+    impl.list_loadbalancers.return_value = [{'name': 'name'}]
+    impl.show_loadbalancer.return_value = {'id': '2345',
+                                           'provisioning_status': 'ACTIVE',
+                                           'vip_address': '1.1.1.1',
+                                           'vip_port_id': '4321'}
+    impl.find_secgrp.return_value = 'sg_id'
+    impl.list_sg_rules.return_value = [{'Port Range': '', 'IP Range': ''}]
+    impl.get_port_sec_enabled.return_value = False
+    impl.list_listeners.return_value = [{'name': 'name'}]
+    impl.list_pools.return_value = [{'name': 'name'}]
+    impl.list_fips.return_value = [
+        {'Fixed IP Address': '2.2.2.2', 'Floating IP Address': '3.3.3.3'},
+        {'Fixed IP Address': '1.1.1.1', 'Floating IP Address': '4.4.4.4'},
+    ]
+    impl.list_members.return_value = ['members']
+    lb.create()
+    assert lb.sg_id is None
+    assert lb.fip == '4.4.4.4'
+    assert lb.address == '1.1.1.1'
+    assert lb.members == ['members']
+    assert lb.is_created
+    assert not impl.create_loadbalancer.called
+    assert not impl.create_secgrp.called
+    assert not impl.create_listener.called
+    assert not impl.create_pool.called
+    assert not impl.create_fip.called
+
+
+def test_wait_not_pending(impl):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    test_func = mock.Mock(side_effect=[
+        {'provisioning_status': 'PENDING_CREATE'},
+        {'provisioning_status': 'PENDING_UPDATE'},
+        {'provisioning_status': 'PENDING_DELETE'},
+        {'provisioning_status': 'ACTIVE'},
+    ])
+    lb._wait_not_pending(test_func)
+    assert sleep.call_count == 3
+
+    test_func = mock.Mock(return_value={
+        'provisioning_status': 'PENDING_DELETE',
+    })
+    with pytest.raises(openstack.OpenStackLBError):
+        lb._wait_not_pending(test_func)
+
+
+def test_find_matching_sg_rule(impl):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    lb.address = '1.1.1.1'
+
+    impl.list_sg_rules.return_value = [{'Port Range': None,
+                                        'IP Range': None}]
+    assert lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
+
+    impl.list_sg_rules.return_value = [{'Port Range': '60:90',
+                                        'IP Range': ''}]
+    assert lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
+
+    impl.list_sg_rules.return_value = [{'Port Range': '',
+                                        'IP Range': '1.0.0.0/8'}]
+    assert lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
+
+    impl.list_sg_rules.return_value = [{'Port Range': '81:90',
+                                        'IP Range': ''},
+                                       {'Port Range': '',
+                                        'IP Range': '2.0.0.0/8'}]
+    assert not lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
+
+    impl.list_sg_rules.return_value = []
+    assert not lb._find_matching_sg_rule('sg_id', lb.address, lb.port)
+
+
+def test_find(impl, log_err):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    lb.name = 'lb'
+    item1 = {'id': 1, 'name': 'not-lb'}
+    item2 = {'id': 2, 'name': 'lb'}
+    item3 = {'id': 3, 'name': 'lb'}
+    assert lb._find('foo', [item1]) is None
+    assert lb._find('foo', [item1, item2]) == item2
+    with pytest.raises(openstack.OpenStackLBError):
+        lb._find('foo', [item1, item2, item3])
+    log_err.assert_called_with('Multiple {} found: {}', 'foo', 'lb')
+
+
+def test_update_members(impl, _openstack):
+    lb = openstack.LoadBalancer('app', '80', 'subnet', 'alg', None, False)
+    lb.address = '1.1.1.1'
+    impl.show_pool.return_value = {'provisioning_status': 'ACTIVE'}
+    impl.list_sg_rules.return_value = []
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(1, 2), (3, 4)})
+    assert not impl.delete_member.called
+    assert not impl.create_member.called
+    assert not impl.create_sg_rule.called
+
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(1, 2), (3, 4), (5, 6)})
+    assert not impl.delete_member.called
+    assert impl.create_member.called
+    assert lb.members == {(1, 2), (3, 4), (5, 6)}
+    assert impl.create_sg_rule.called
+
+    impl.create_member.reset_mock()
+    impl.create_sg_rule.reset_mock()
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(1, 2)})
+    assert impl.delete_member.called
+    assert not impl.create_member.called
+    assert not impl.create_sg_rule.called
+
+    impl.delete_member.reset_mock()
+    lb.members = {(1, 2), (3, 4)}
+    lb.update_members({(5, 6)})
+    assert impl.delete_member.called
+    assert impl.create_member.called
+
+    impl.delete_member.side_effect = subprocess.CalledProcessError(1, 'cmd')
+    lb.members = {(1, 2), (3, 4)}
+    with pytest.raises(openstack.OpenStackLBError):
+        lb.update_members(set())
+
+    impl.delete_member.side_effect = AssertionError('should not be called')
+    impl.create_member.side_effect = subprocess.CalledProcessError(1, 'cmd')
+    lb.members = set()
+    with pytest.raises(openstack.OpenStackLBError):
+        lb.update_members({(1, 2)})
+
+
+def test_is_base64():
+    cert = ('-----BEGIN CERTIFICATE-----\nMIIDITCCAgmgAwIBAgIUeQxHSsZt6auk1oW+'
+            'SRFXC4T6nNcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVUsxETAPBgNVBAo'
+            'MCElubWFyc2F0MB4XDTE5MTEwNDE1\nMTQzOFoXDTI5MTEwMTE1MTQzOFowIDELMA'
+            'kGA1UEBhMCVUsxETAPBgNVBAoMCElu\nbWFyc2F0MIIBIjANBgkqhkiG9w0BAQEFA'
+            'AOCAQ8AMIIBCgKCAQEA09qCmv8jF+N1\ndl/ae3VQV95FG7WFrjS6fbZ1TpXkO9Vs'
+            'PKhA9lRUBxs58noKIkMIUeXYy4wvSu28\nX67NqB2bv3iyns/mEzPYE1GxtFXIPhk'
+            'KO22vqVLZ0CFAuV47AhqDOXtyqwwfxoBT\nKxMi430UCb+3cPaev/mZMlvf6iJfdi'
+            'hyPfMEwtIanS/QKgEvykhP1kAZ36ActFmK\nWnJtjBBFUKQIBQzguMTqUXX7wvwRe'
+            'gK8lgXiZ6iZiOza0C7hSdBVylcKeaqoLnP5\nW93m3YZTXc08A30PieTJQFD6Bm+4'
+            '1Kv2FxQAXjRnCzvIJL44zJXjLmnUdZbSzdl8\nPpu3wJu9cQIDAQABo1MwUTAdBgN'
+            'VHQ4EFgQUwQsYIyqud2WQkAlcDwIuu7nAvnYw\nHwYDVR0jBBgwFoAUwQsYIyqud2'
+            'WQkAlcDwIuu7nAvnYwDwYDVR0TAQH/BAUwAwEB\n/zANBgkqhkiG9w0BAQsFAAOCA'
+            'QEAn5oQYeyaxcqOjzUxbkEy4pOJMg/nTKkt+8yh\nFSqUv1Vc3HGg65uGq08eJDq9'
+            'AP7PrfvSQJWQpFBS80bNN8idCmhMutpA8X6+Z0wv\n0p5dzQFAUdSLLN0so4iXKtP'
+            'k5wp0r84W0xbqWPRWRSw+lCe1WrMK+ARDpPv+AxOW\nf7JFQkqzEsWu6RCjy0KobO'
+            'y7PPq17wXEhXynNcMAXjQe9DkTBb34K6PYku1Ftxfr\n3IRWaSrDB9BJTje6/tmz7'
+            'IcO8ss+Y3gUZeaqTLdZz8RJUlJqNqfdTQif2hKLYjro\nBwZYRQo8TkDmSlz00LwQ'
+            'So1xLX27nGHB621pgNCZbJMKvZOrQg==\n-----END CERTIFICATE-----\n')
+    cert = cert.encode('utf8')
+    assert openstack._is_base64(cert) is False
+    # Base64 encoded foobar string
+    foobar = 'Zm9vYmFyCg==\n'.encode('utf8')
+    assert openstack._is_base64(foobar)
+
+
+def test_series_upgrade():
+    assert charms.layer.status.blocked.call_count == 0
+    reactive.openstack.pre_series_upgrade()
+    assert charms.layer.status.blocked.call_count == 1
+
+
+def test_get_credentials(_normalize_creds, _save_creds, log_err):
+    openstack.hookenv.config.return_value = config = {
+        'credentials': None,
+    }
+    subprocess.run.side_effect = MockCalledProcessError(1, b'foo')
+    with pytest.raises(MockCalledProcessError):
+        openstack.get_credentials()
+
+    subprocess.run.side_effect = MockCalledProcessError(1,
+                                                        b'permission denied')
+    _normalize_creds.side_effect = ValueError('unsupported auth-type')
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with('unsupported auth-type')
+
+    _normalize_creds.reset_mock()
+    status.blocked.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with('unsupported auth-type')
+    assert _normalize_creds.call_args_list == [
+        mock.call({'credentials': None}),
+    ]
+
+    status.blocked.reset_mock()
+    _normalize_creds.reset_mock()
+    _normalize_creds.side_effect = lambda a: a
+    stdout = b'{}'
+    subprocess.run.side_effect = lambda *a, **k: mock.Mock(stdout=stdout)
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with(
+        'missing credentials; grant with `juju trust` or set via config')
+    assert _normalize_creds.call_args_list == [
+        mock.call({}),
+        mock.call({'credentials': None}),
+    ]
+
+    _normalize_creds.reset_mock()
+    stdout = b'{"foo": "bar"}'
+    assert openstack.get_credentials() is False
+    assert _normalize_creds.call_args_list == [
+        mock.call({'foo': 'bar'}),
+        mock.call({'credentials': None}),
+    ]
+
+    status.blocked.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    config['credentials'] = 'foo'
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with(
+        'invalid value for credentials config: Incorrect padding')
+
+    status.blocked.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    config['credentials'] = 'ewo='
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with(
+        'invalid value for credentials config: Expecting property name '
+        'enclosed in double quotes: line 2 column 1 (char 2)')
+
+    _normalize_creds.reset_mock()
+    subprocess.run.side_effect = FileNotFoundError()
+    config['credentials'] = 'eyJmb28iOiAiYmFyIn0K'
+    assert openstack.get_credentials() is False
+    assert _normalize_creds.call_args_list == [
+        mock.call({'foo': 'bar'}),
+        mock.call({'credentials': 'eyJmb28iOiAiYmFyIn0K'}),
+    ]
+
+    config.update({
+        'credentials': None,
+        'auth_url': 'auth-url',
+        'region': 'region',
+        'username': 'username',
+        'password': 'password',
+        'user_domain_name': 'user-domain-name',
+        'project_domain_name': 'project-domain-name',
+        'project_name': 'project-name',
+    })
+    expected = config.copy()
+    del expected['credentials']
+    expected['endpoint_tls_ca'] = ''
+    assert openstack.get_credentials() is True
+    _save_creds.assert_called_with(expected)
+
+    _save_creds.reset_mock()
+    status.blocked.reset_mock()
+    config['region'] = ''
+    assert openstack.get_credentials() is False
+    assert not _save_creds.called
+    status.blocked.assert_called_with('missing required credential: region')
+
+    status.blocked.reset_mock()
+    config['username'] = ''
+    assert openstack.get_credentials() is False
+    status.blocked.assert_called_with('missing required credentials: '
+                                      'region, username')
+
+
+def test_normalize_creds(_determine_version, log_err):
+    _determine_version.return_value = '3'
+    with pytest.raises(ValueError) as excinfo:
+        openstack._normalize_creds({'auth-type': 'allow'})
+    assert str(excinfo.value) == 'unsupported auth-type in credentials: allow'
+    with pytest.raises(ValueError) as excinfo:
+        openstack._normalize_creds({
+            'endpoint': '/',
+            'credential': {
+                'attributes': {
+                    'auth-type': 'allow',
+                },
+            },
+        })
+    assert str(excinfo.value) == 'unsupported auth-type in credentials: allow'
+    assert openstack._normalize_creds({}) == dict(
+        auth_url='',
+        region='',
+        username=None,
+        password=None,
+        user_domain_name=None,
+        project_domain_name=None,
+        project_name=None,
+        endpoint_tls_ca=None,
+        version='3',
+    )
+    _determine_version.assert_called_with({}, '')
+    attrs = {
+        'auth-url': 'auth-url',
+        'region': 'us-east-1',
+        'username': 'username',
+        'password': 'password',
+        'user-domain-name': 'user-domain-name',
+        'project-domain-name': 'project-domain-name',
+        'tenant-name': 'tenant-name',
+    }
+    expected = dict(
+        auth_url='auth-url',
+        region='us-east-1',
+        username='username',
+        password='password',
+        user_domain_name='user-domain-name',
+        project_domain_name='project-domain-name',
+        project_name='tenant-name',
+        endpoint_tls_ca=None,
+        version='3',
+    )
+    assert openstack._normalize_creds(attrs) == expected
+    assert openstack._normalize_creds({
+        'endpoint': 'endpoint',
+        'region': 'region',
+        'credential': {'attributes': attrs},
+    }) == dict(expected, auth_url='endpoint', region='region')
+
+    attrs['project-name'] = expected['project_name'] = 'project-name'
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['ca-certificates'] = []
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['ca-certificates'] = ['ca-cert']
+    expected['endpoint_tls_ca'] = 'Y2EtY2VydA=='
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['ca-certificates'] = ['Y2EtY2VydA==']
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['cacertificates'] = attrs.pop('ca-certificates')
+    assert openstack._normalize_creds(attrs) == expected
+
+    attrs['endpoint-tls-ca'] = attrs.pop('cacertificates')[0]
+    assert openstack._normalize_creds(attrs) == expected
+
+
+@pytest.mark.parametrize("ids,skip_ids,check_all,exp_cmd", [
+    ("1,2", "", False, "--id 1 --id 2"),
+    ("all", "1,2", True, "--all --skip-id 1 --skip-id 2"),
+    ("all", "1,2", True, "--all --skip-id 1 --skip-id 2"),
+])
+def test_create_nrpe_check_cmd(ids, skip_ids, check_all, exp_cmd):
+    """Test creating cmd for NRPE check."""
+    cmd = openstack.create_nrpe_check_cmd("check_openstack.py", "interface",
+                                          ids, skip_ids, check_all)
+
+    assert exp_cmd in cmd
+
+
+@pytest.mark.parametrize("ids,skip_ids,check_all", [
+    ("all", "", False),
+    ("1,2", "1", True),
+])
+def test_create_nrpe_check_cmd_error(ids, skip_ids, check_all):
+    """Test creating cmd for NRPE check."""
+    with pytest.raises(ValueError):
+        openstack.create_nrpe_check_cmd("check_openstack.py", "interface",
+                                        ids, skip_ids, check_all)

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,13 @@ deps =
     flake8
     ipdb
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
-commands = pytest --tb native -s {posargs}
+    python-openstackclient
 
 [testenv:py3]
+commands =
+    {basepython} {toxworkdir}/../tests/nagios/plugins/download_nagios_plugin3.py {envdir}
+    pytest --tb native -s {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py3
-commands = flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
+commands = flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests {toxinidir}/files


### PR DESCRIPTION
This review will provide  NRPE checks on OpenStack components that
are managed by the openstack-integrator. These checks on behalf of
Kubernetes will ensure that all OpenStack components configured by
the openstack-integrator are monitored and reported via the nagios system.

Adding all the checks NRPE requires extensive changes and therefore it's
divided into two parts. This is the first part of the changes and includes 
NRPE control for server, network, port, floating-ip, security-group and subnet. 
The second part will contain an NRPE check for the loadbalancer.

Related-Bug: #1853886