### PR TITLE
Update example command to be more accurate

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ options:
 
       This can be used from bundles with 'include-base64://' (see
       https://jujucharms.com/docs/stable/charms-bundles#setting-charm-configurations-options-in-a-bundle),
-      or from the command-line with 'juju config openstack credentials="$(base64 /path/to/file)"'.
+      or from the command-line with 'juju config openstack-integrator credentials="$(base64 /path/to/file)"'.
 
       It is strongly recommended that you use 'juju trust' instead, if available.
     type: string


### PR DESCRIPTION
Update `juju config` command to use the right application name.

Fixes bug: https://bugs.launchpad.net/charm-openstack-integrator/+bug/1911813