### PR TITLE
update octavia detection logic to verify endpoint is in same region

### DIFF
--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -130,14 +130,20 @@ def detect_octavia():
     """
     Determine whether the underlying OpenStack is using Octavia or not.
 
-    Returns True if Octavia is found, and False otherwise.
+    Returns True if Octavia is found in the region, and False otherwise.
     """
     try:
-        catalog = {s['Name'] for s in _openstack('catalog', 'list')}
+        creds = _load_creds()
+        region = creds['region']
+        for catalog in _openstack('catalog', 'list'):
+            if (catalog['Name'] == 'octavia' and catalog.get('Endpoints')
+                    and catalog['Endpoints'][0]['region'] == region):
+                return True
     except Exception:
         log_err('Error while trying to detect Octavia\n{}', format_exc())
-        return None
-    return 'octavia' in catalog
+        return False
+
+    return False
 
 
 def manage_loadbalancer(app_name, members):


### PR DESCRIPTION
Octavia detection logic does not take region into consideration.
This patch adds logic to verify if octavia endpoint is of same
region as credentials passed onto openstack-integrator charm.

Fixes lp:1919940