### PR TITLE
Fix CA cert path so it's readable by openstackclients snap

### DIFF
--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -23,7 +23,7 @@ from charms.layer import status
 # during normal hook execution, it's /root. Set it here to be consistent.
 os.environ['HOME'] = '/root'
 
-CA_CERT_FILE = Path('/etc/openstack-integrator/ca.crt')
+CA_CERT_FILE = Path('/var/snap/openstackclients/common/ca.crt')
 MODEL_UUID = os.environ['JUJU_MODEL_UUID']
 MODEL_SHORT_ID = MODEL_UUID.split('-')[-1]
 config = hookenv.config()


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-openstack-integrator/+bug/1922720

The openstackclients snap has strict confinement and cannot read /etc/openstack-integrator. Write ca.crt to openstackclients' $SNAP_COMMON instead.

The CA cert is rendered prior to every openstack client call [here](https://github.com/juju-solutions/charm-openstack-integrator/blob/bfe7601fd5fead0d6d375b65a06961522648c393/lib/charms/layer/openstack.py#L299), so this fix should work for both new and upgraded deployments.

Tested in an openstack env with SSL. Before fix:
```
unit-openstack-integrator-0: 16:29:23 INFO unit.openstack-integrator/0.juju-log loadbalancer:17: Managing load balancer for kubernetes-master
unit-openstack-integrator-0: 16:29:26 WARNING unit.openstack-integrator/0.loadbalancer-relation-joined Failed to discover available identity versions when contacting https://10.5.0.27/v3. Attempting to parse version from URL.
unit-openstack-integrator-0: 16:29:26 WARNING unit.openstack-integrator/0.loadbalancer-relation-joined SSL exception connecting to https://10.5.0.27/v3/auth/tokens: HTTPSConnectionPool(host='10.5.0.27', port=443): Max retries exceeded with url: /v3/auth/tokens (Caused by SSLError(SSLError("unable to load trusted certificates: Error([('system library', 'fopen', 'Permission denied'), ('BIO routines', 'BIO_new_file', 'system lib'), ('x509 certificate routines', 'X509_load_cert_crl_file', 'system lib')],)",),))
unit-openstack-integrator-0: 16:29:26 DEBUG jujuc running hook tool "juju-log" for openstack-integrator/0-loadbalancer-relation-joined-2012562655777321950
unit-openstack-integrator-0: 16:29:26 ERROR unit.openstack-integrator/0.juju-log loadbalancer:17: Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-openstack-integrator-0/.venv/lib/python3.8/site-packages/charms/reactive/__init__.py", line 74, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-openstack-integrator-0/.venv/lib/python3.8/site-packages/charms/reactive/bus.py", line 390, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-openstack-integrator-0/.venv/lib/python3.8/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-openstack-integrator-0/.venv/lib/python3.8/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-openstack-integrator-0/charm/reactive/openstack.py", line 127, in create_or_update_loadbalancers
    lb = layer.openstack.manage_loadbalancer(request.application_name,
  File "lib/charms/layer/openstack.py", line 151, in manage_loadbalancer
    subnet = config['lb-subnet'] or _default_subnet(members)
  File "lib/charms/layer/openstack.py", line 350, in _default_subnet
    for subnet_info in _openstack('subnet', 'list'):
  File "lib/charms/layer/openstack.py", line 312, in _openstack
    output = _run_with_creds('openstack', *args, '--format=yaml')
  File "lib/charms/layer/openstack.py", line 303, in _run_with_creds
    result = subprocess.run(args,
  File "/usr/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('openstack', 'subnet', 'list', '--format=yaml')' returned non-zero exit status 1.
```

After fix:
```
unit-openstack-integrator-0: 16:30:17 INFO unit.openstack-integrator/0.juju-log loadbalancer:17: Managing load balancer for kubernetes-master
unit-openstack-integrator-0: 16:30:33 WARNING unit.openstack-integrator/0.loadbalancer-relation-joined neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
unit-openstack-integrator-0: 16:30:38 WARNING unit.openstack-integrator/0.loadbalancer-relation-joined neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
...
```