### PR TITLE
Fix failure to propagate updated cloud credentials

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+refresh-credentials:
+  description: Force the charm to recheck cloud credentials

--- a/actions/refresh-credentials
+++ b/actions/refresh-credentials
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+charms.reactive clear_flag charm.openstack.creds.set
+exec hooks/config-changed

--- a/actions/refresh-credentials
+++ b/actions/refresh-credentials
@@ -1,5 +1,8 @@
-#!/bin/bash
-set -euxo pipefail
+#!/usr/local/sbin/charm-env python3
 
-charms.reactive clear_flag charm.openstack.creds.set
-exec hooks/config-changed
+import charms.layer
+import charms.reactive
+
+charms.reactive.clear_flag('charm.openstack.creds.set')
+charms.layer.import_layer_libs()
+charms.reactive.main()

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -37,9 +37,9 @@ def log_err(msg, *args):
     hookenv.log(msg.format(*args), hookenv.ERROR)
 
 
-def get_credentials():
+def update_credentials():
     """
-    Get the credentials from either the config or the hook tool.
+    Update the credentials from either the config or the hook tool.
 
     Prefers the config so that it can be overridden.
     """
@@ -122,7 +122,7 @@ def get_credentials():
         return False
 
 
-def get_user_credentials():
+def get_credentials():
     return _load_creds()
 
 

--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -186,7 +186,7 @@ class OpenStackError(Exception):
 
 class OpenStackLBError(OpenStackError):
     def __init__(self, action, exc=True):
-        action = action[:-1]+'ing'
+        action = action[:-1] + 'ing'
         if exc:
             log_err('Error {} loadbalancer\n{}', action, format_exc())
         super().__init__('Error while {} load balancer; '

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -54,9 +54,10 @@ def pre_series_upgrade():
 
 @when_not('charm.openstack.creds.set')
 def get_creds():
-    prev_creds = layer.openstack.get_user_credentials()
-    toggle_flag('charm.openstack.creds.set', layer.openstack.get_credentials())
-    creds = layer.openstack.get_user_credentials()
+    prev_creds = layer.openstack.get_credentials()
+    credentials_exist = layer.openstack.update_credentials()
+    toggle_flag('charm.openstack.creds.set', credentials_exist)
+    creds = layer.openstack.get_credentials()
     if creds != prev_creds:
         set_flag('charm.openstack.creds.changed')
 
@@ -97,7 +98,7 @@ def handle_requests():
     for request in requests:
         layer.status.maintenance(
             'Granting request for {}'.format(request.unit_name))
-        creds = layer.openstack.get_user_credentials()
+        creds = layer.openstack.get_credentials()
         request.set_credentials(**creds)
         request.set_lbaas_config(config['subnet-id'],
                                  config['floating-network-id'],

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -7,6 +7,7 @@ from charms.reactive import (
     when_not,
     is_flag_set,
     toggle_flag,
+    set_flag,
     clear_flag,
 )
 from charms.reactive.relations import endpoint_from_name
@@ -40,6 +41,12 @@ def upgrade_charm():
     clear_flag('charm.openstack.creds.set')
 
 
+@hook('update-status')
+def update_status():
+    # need to recheck creds in case the credentials from Juju have changed
+    clear_flag('charm.openstack.creds.set')
+
+
 @hook('pre-series-upgrade')
 def pre_series_upgrade():
     layer.status.blocked('Series upgrade in progress')
@@ -47,7 +54,11 @@ def pre_series_upgrade():
 
 @when_not('charm.openstack.creds.set')
 def get_creds():
+    prev_creds = layer.openstack.get_user_credentials()
     toggle_flag('charm.openstack.creds.set', layer.openstack.get_credentials())
+    creds = layer.openstack.get_user_credentials()
+    if creds != prev_creds:
+        set_flag('charm.openstack.creds.changed')
 
 
 @when_all('snap.installed.openstackclients',
@@ -62,7 +73,7 @@ def no_requests():
           'charm.openstack.creds.set',
           'endpoint.clients.joined')
 @when_any('endpoint.clients.requests-pending',
-          'config.changed')
+          'config.changed', 'charm.openstack.creds.changed')
 @when_not('upgrade.series.in-progress')
 def handle_requests():
     layer.status.maintenance('Granting integration requests')
@@ -80,7 +91,9 @@ def handle_requests():
     except AttributeError:
         # in case manage_security_groups is already bool
         manage_security_groups = config['manage-security-groups']
-    requests = clients.all_requests if config_change else clients.new_requests
+    creds_changed = is_flag_set('charm.openstack.creds.changed')
+    refresh_requests = config_change or creds_changed
+    requests = clients.all_requests if refresh_requests else clients.new_requests
     for request in requests:
         layer.status.maintenance(
             'Granting request for {}'.format(request.unit_name))
@@ -103,6 +116,7 @@ def handle_requests():
             _or_none(config.get('ignore-volume-az')))
         layer.openstack.log('Finished request for {}', request.unit_name)
     clients.mark_completed()
+    clear_flag('charm.openstack.creds.changed')
 
 
 @when_all('charm.openstack.creds.set',

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,8 @@
+[flake8]
+max-line-length = 88
+ignore =
+    W503 # line break before binary operator
+
 [tox]
 skipsdist = True
 envlist = lint,py3


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-openstack-integrator/+bug/1939596

When the cloud credentials from Juju change, the charm is not notified. Check for changed credentials during update-status, but also add a refresh-credentials action in case the user needs the credentials updated sooner.