### PR TITLE
Fix octavia detection logic when octavia exists on multiple regions

### DIFF
--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -138,9 +138,10 @@ def detect_octavia():
         creds = _load_creds()
         region = creds['region']
         for catalog in _openstack('catalog', 'list'):
-            if (catalog['Name'] == 'octavia' and catalog.get('Endpoints')
-                    and catalog['Endpoints'][0]['region'] == region):
-                return True
+            if catalog['Name'] == 'octavia':
+                for endpoint in catalog.get('Endpoints', []):
+                    if endpoint['region'] == region:
+                        return True
     except Exception:
         log_err('Error while trying to detect Octavia\n{}', format_exc())
         return False


### PR DESCRIPTION
PR 49 [1] updated the Octavia detection logic to consider region
name. However the change checks if region is same only for first
endpoint. In case of multiple regions deploying Octavia, this will
fail.

The fix updates the Octavia detection logic to verify if any one of
the endpoint matches the region name.

Fixes lp:1947085

[1] https://github.com/juju-solutions/charm-openstack-integrator/pull/49