### PR TITLE
Add internal-lb config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -136,3 +136,9 @@ options:
       will use the upstream default.
     type: boolean
     default: null
+  internal-lb:
+    description: |
+      Determines whether or not to create an internal load balancer
+      (no floating IP) by default.
+    type: boolean
+    default: false

--- a/reactive/openstack.py
+++ b/reactive/openstack.py
@@ -104,7 +104,8 @@ def handle_requests():
                                  config['floating-network-id'],
                                  config['lb-method'],
                                  manage_security_groups,
-                                 has_octavia)
+                                 has_octavia,
+                                 internal_lb=config['internal-lb'])
 
         def _or_none(val):
             if val in (None, '', 'null'):


### PR DESCRIPTION
This is ultimately a configuration option for cloud provider openstack.
This new option is passed to the openstack integrator interface,
to be used by charm-kubernetes-control-plane
to set config for cloud-provider-openstack.

Related PRs:
- https://github.com/juju-solutions/interface-openstack-integration/pull/12
- https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/26

Launchpad bug: [#1877692](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1877692)