### PR TITLE
Fix unittests and integration tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9, '3.10']
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -22,23 +22,5 @@ jobs:
       - name: Run test
         run: tox -e unit
 
-  integration-tests:
-    name: Integration test with Microstack
-    runs-on: self-hosted
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microstack
-      - name: Create custom flavor to save resources
-        run: openstack flavor show m2.medium || openstack flavor create --vcpus 4 --ram 4096 --disk 20 m2.medium
-      - name: source Microstack credentials
-        run: source /var/snap/microstack/common/etc/microstack.rc
-      - name: Run test
-        run: tox -e integration
+# NOTE (rgildein): Functional tests have been replaced from the GitHub workflow until
+# a replacement for Microstak as a cloud is found.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,26 @@ The workflow for contributing code is as follows:
 
 Documentation for this charm is currently maintained as part of the Charmed Kubernetes docs.
 See [this page](https://github.com/charmed-kubernetes/kubernetes-docs/blob/master/pages/k8s/charm-openstack-integrator.md)
+
+
+## Testing
+
+All tests are run by [tox][].
+
+### Lint and Unittest
+
+These tests cloud be run by `tox -e lint` and `tox -e unit`, and they do not require
+any specific requirements.
+
+### Integration tests
+
+The integration tests deploy charmed-kubernetes and charm-openstack integration.
+Tests required to be run on top of OpenStack cloud with credentials for
+openstack-integrator, since it is deployed with `--trust`.
+
+```bash
+source <path-to-openrc>
+tox -e integration
+```
+
+[tox]: https://tox.wiki/en/latest/

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -1,40 +1,37 @@
-description: A minimal two-machine Kubernetes cluster + one machine for openstack-integrator.
+description: A minimal two-machine Kubernetes cluster.
 series: {{ series }}
 machines:
   '0':
-    constraints: cores=4 mem=4G root-disk=16G
+    constraints: cores=2 mem=4G root-disk=16G
     series: {{ series }}
   '1':
-    constraints: cores=4 mem=4G root-disk=16G
-    series: {{ series }}
-  '2':
-    constraints: cores=2 mem=2G root-disk=16G
+    constraints: cores=2 mem=4G root-disk=16G
     series: {{ series }}
 applications:
+  flannel:
+    charm: flannel
+    channel: latest/edge
   containerd:
-    charm: cs:~containers/containerd
-    channel: edge
+    charm: containerd
+    channel: latest/edge
   easyrsa:
-    charm: cs:~containers/easyrsa
-    channel: edge
+    charm: easyrsa
+    channel: latest/edge
     num_units: 1
     to:
-    - '1'
+    - 'lxd:0'
   etcd:
-    charm: cs:~containers/etcd
-    channel: edge
+    charm: etcd
+    channel: latest/edge
     num_units: 1
     options:
       channel: 3.4/stable
     to:
     - '0'
-  flannel:
-    charm: cs:~containers/flannel
-    channel: edge
   kubernetes-control-plane:
     charm: kubernetes-control-plane
     channel: latest/edge
-    constraints: cores=4 mem=4G root-disk=16G
+    constraints: cores=2 mem=4G root-disk=16G
     expose: true
     num_units: 1
     options:
@@ -42,22 +39,15 @@ applications:
     to:
     - '0'
   kubernetes-worker:
-    charm: cs:~containers/kubernetes-worker
+    charm: kubernetes-worker
     channel: edge
-    constraints: cores=4 mem=4G root-disk=16G
+    constraints: cores=2 mem=4G root-disk=16G
     expose: true
     num_units: 1
     options:
       channel: 1.21/stable
     to:
     - '1'
-  openstack-integrator:
-    charm: {{ master_charm }}
-    num_units: 1
-    trust: true
-    constraints: cores=2 mem=2G root-disk=16G
-    to:
-    - '2'
 
 relations:
 - - kubernetes-control-plane:kube-api-endpoint
@@ -82,7 +72,3 @@ relations:
   - kubernetes-worker:container-runtime
 - - containerd:containerd
   - kubernetes-control-plane:container-runtime
-- - openstack-integrator:clients
-  - kubernetes-control-plane:openstack
-- - openstack-integrator:clients
-  - kubernetes-worker:openstack

--- a/tests/integration/test_openstack_integrator_integration.py
+++ b/tests/integration/test_openstack_integrator_integration.py
@@ -2,25 +2,41 @@ import logging
 
 import pytest
 
-
 log = logging.getLogger(__name__)
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test):
-    """Build and deploy openstack-integrator in bundle"""
-    openstack_integrator = await ops_test.build_charm(".")
-    bundle = ops_test.render_bundle(
-        "tests/data/bundle.yaml", master_charm=openstack_integrator, series="focal"
-    )
-    await ops_test.model.deploy(bundle, trust=True)
+    """Build and deploy openstack-integrator in bundle."""
+    bundle = ops_test.render_bundle("tests/data/bundle.yaml", series="focal")
+    await ops_test.model.deploy(bundle)
     await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
+
+    openstack_integrator = await ops_test.build_charm(".")
+    await ops_test.model.deploy(openstack_integrator, to="lxd:0", trust=True)
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
+
+
+async def test_add_relations(ops_test):
+    """Test adding openstack-integrator relations.
+
+    This will test adding relations
+    `openstack-integrator:clients kubernetes-control-plane:openstack` and
+    `openstack-integrator:clients kubernetes-worker:openstack`.
+    """
+    await ops_test.model.relate(
+        "openstack-integrator:clients", "kubernetes-control-plane:openstack"
+    )
+    await ops_test.model.relate(
+        "openstack-integrator:clients", "kubernetes-worker:openstack"
+    )
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
 
 
 async def test_status_messages(ops_test):
     """Validate that the status messages are correct."""
     expected_messages = {
-        "kubernetes-control-plane": "Kubernetes master running.",
+        "kubernetes-control-plane": "Kubernetes control-plane running.",
         "kubernetes-worker": "Kubernetes worker running.",
         "openstack-integrator": "Ready",
     }


### PR DESCRIPTION
- Deploying the openstack-integrator after the model is ready, this will
  prevent the openstack-integrator from invading other services in the
  kube-system namespace.
- Change chart source to Charmhub instead of Charmstore.
- Moving from `containers-<charm>` to `<charm>`.
- Removing integration tests from GitHub workflows.
- Add short notes about testing into CONTRIBUTING.md.