### PR TITLE
[LP#1964544] Fix endpoint url regex to parse trailing slash

### DIFF
--- a/lib/charms/layer/openstack.py
+++ b/lib/charms/layer/openstack.py
@@ -320,7 +320,7 @@ def _determine_version(attrs, endpoint):
     if attrs.get('version'):
         return str(attrs['version'])
 
-    url_ver = re.search(r'/v?(\d+(.\d+)?)$', endpoint)
+    url_ver = re.search(r'/v?(\d+(.\d+)?)/?$', endpoint)
     if url_ver:
         return url_ver.group(1)
 


### PR DESCRIPTION
The endpoint url regex fails to parse URL with
trailing slash. Add ?/ to regex to parse trailing
slash.

Fixes: https://bugs.launchpad.net/charm-openstack-integrator/+bug/1964544